### PR TITLE
fix(cv): remove stale jusmundi references

### DIFF
--- a/public/cv/index.html
+++ b/public/cv/index.html
@@ -514,11 +514,8 @@
                       <div class="list-group-item d-flex justify-content-between align-items-center">
                         <div>
                           <i class="fa fa-briefcase text-primary mr-2"></i>
-                          <strong>Jusmundi — 4 Years Achievements</strong>
-                          <p class="mb-0 text-muted small">Key KPIs, Security (CVE, Keycloak SSO, ISO, SOC), SEO &amp; SLA improvements (2022–2025)</p>
-                        </div>
-                        <div>
-                          <a href="/cv/jusmundi/index.html" class="btn btn-sm btn-outline-primary mr-2">View page</a>
+                          <strong>Private legal-tech engagement summary</strong>
+                          <p class="mb-0 text-muted small">High-level outcomes are available on request; detailed metrics remain private.</p>
                         </div>
                       </div>
                     </div>

--- a/public/index.html
+++ b/public/index.html
@@ -281,8 +281,6 @@
 				</div>
 				<p class="section-subtitle mt-4 mb-0">
 					<a href="/expertise">More detail on selected outcomes</a>
-					—
-					<a href="cv/jusmundi/">See Jus Mundi experience</a>
 				</p>
 			</section>
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -173,11 +173,6 @@ Disallow: /api/
 Disallow: /test/
 Crawl-delay: 10
 
-# Disallow Jusmundi review pages (noindex/nofollow, not for public indexing)
-Disallow: /cv/jusmundi/4-years-review-aandrieu.html
-Disallow: /cv/jusmundi/4-years-review-jusmundi.html
-Disallow: /cv/jusmundi/yearly-review-2025-aandrieu.html
-
 # Disallow test and login pages (noindex/nofollow)
 Disallow: /test.html
 Disallow: /login.html


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- follow up the historical removal of `public/cv/jusmundi` from commit `dcc67d30fe72303759f894bb9cc5b2a5909e64d0`
- remove stale public links that still pointed to deleted `cv/jusmundi` pages
- replace the CV data-driven entry text with a generic private-engagement description (no detailed security/stack/KPI claims)
- remove obsolete robots.txt entries targeting deleted jusmundi pages

## What was reviewed
- verified that `public/cv/jusmundi/` is absent in the current tree
- inspected historical deleted pages from the parent of `dcc67d3` to confirm they contained detailed internal/team/infrastructure/technology content
- checked current `public/` references for remaining `cv/jusmundi` links and removed them

## Files changed
- `public/index.html`
- `public/cv/index.html`
- `public/robots.txt`

## Validation
- searched `public/` for `/cv/jusmundi` references and confirmed none remain
- searched for the prior CV card wording and confirmed it is removed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e1018bf-af5b-4601-a7a0-febc80992c2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e1018bf-af5b-4601-a7a0-febc80992c2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

