### PR TITLE
feat(cv): restore and restructure jusmundi portfolio content

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"deploy": "wrangler deploy",
 		"dev:cf": "wrangler dev",
 		"start:wrangler": "wrangler dev",
-		"start:python": "python -m http.server 8001 --directory public",
+		"start:python": "python3 -m http.server 8001 --directory public",
 		"start:php:": "php -S localhost:8000 api/index.php",
 		"start:stripe": "node server.cjs",
 		"test": "playwright test",

--- a/public/ai.html
+++ b/public/ai.html
@@ -863,7 +863,6 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing.html">Pricing</a>
 				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>

--- a/public/ai.html
+++ b/public/ai.html
@@ -863,8 +863,8 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing">Pricing</a>
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/pricing.html">Pricing</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/assets/nabla/signature/signature-nabla.html
+++ b/public/assets/nabla/signature/signature-nabla.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 
-		<link rel="icon" href="assets/nabla/nabla-4.svg" />
+		<link rel="icon" href="../nabla-4.svg" />
 		<title>
 			Alban Andrieu, DevSecOps, IA Engineer, Software Developers, Unix system administrator and data engineer MLOps in
 			NLP LLM
@@ -52,7 +52,7 @@
 		/>
 
 		<!-- Custom CSS -->
-		<link rel="stylesheet" href="landing-sections.css" />
+		<link rel="stylesheet" href="../../../landing-sections.css" />
 	</head>
 	<body>
 		<a name="top"></a>

--- a/public/assets/nabla/signature/signature.html
+++ b/public/assets/nabla/signature/signature.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 
-		<link rel="icon" href="assets/nabla/nabla-4.svg" />
+		<link rel="icon" href="../nabla-4.svg" />
 		<title>
 			Alban Andrieu, DevSecOps, IA Engineer, Software Developers, Unix system administrator and data engineer MLOps in
 			NLP LLM

--- a/public/cancel.html
+++ b/public/cancel.html
@@ -7,10 +7,10 @@
 		<meta name="robots" content="noindex, nofollow" />
 
 		<!-- Favicon -->
-		<link rel="icon" href="../assets/nabla/nabla-4.svg" />
+		<link rel="icon" href="assets/nabla/nabla-4.svg" />
 
 		<!-- Resume Schema Reference for Machine-Readable Tools -->
-		<link rel="alternate" type="application/json" href="./schema.json" title="Resume Schema (JSONResume format)" />
+		<link rel="alternate" type="application/json" href="/cv/schema.json" title="Resume Schema (JSONResume format)" />
 
 		<!-- Font Awesome -->
 		<link
@@ -34,16 +34,16 @@
 		<!-- Theme toggle script - load early to prevent flash -->
 
 		<!-- Custom CSS -->
-		<link rel="stylesheet" href="../landing-sections.css" />
+		<link rel="stylesheet" href="landing-sections.css" />
 
-		<link rel="stylesheet" href="../wireframe.css" />
-		<link rel="stylesheet" href="../arf.css" />
-		<link rel="stylesheet" href="../theme.css" />
+		<link rel="stylesheet" href="wireframe.css" />
+		<link rel="stylesheet" href="arf.css" />
+		<link rel="stylesheet" href="theme.css" />
 
-		<link rel="stylesheet" href="../style.css" />
+		<link rel="stylesheet" href="style.css" />
 		<!-- Print Styles for PDF Export -->
-		<link rel="stylesheet" href="../print.css" />
-		<link rel="stylesheet" href="../site-content-page.css" />
+		<link rel="stylesheet" href="print.css" />
+		<link rel="stylesheet" href="site-content-page.css" />
 
 		<link rel="stylesheet" href="checkout.css" />
 		<script src="theme-toggle.js"></script>
@@ -67,11 +67,11 @@
 				<p class="checkout-message">
 					You can also pay via
 					<a href="https://buy.stripe.com/9B65kF1Gd8hHcr2d69cV200" rel="noopener noreferrer">Stripe’s direct link</a> or
-					<a href="/payment#pay-sepa">Pay by bank transfer (SEPA)</a>
+					<a href="/payment.html#pay-sepa">Pay by bank transfer (SEPA)</a>
 					if you prefer.
 				</p>
 				<p class="checkout-actions">
-					<a href="/payment" class="checkout-button">Back to payment options</a>
+					<a href="/payment.html" class="checkout-button">Back to payment options</a>
 
 					<a href="/" class="checkout-button checkout-button-secondary">Back to site</a>
 				</p>
@@ -121,7 +121,7 @@
 				></a>
 			</div>
 			<div class="footer-links">
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/checkout-tjm.html
+++ b/public/checkout-tjm.html
@@ -7,10 +7,10 @@
 		<meta name="robots" content="noindex, nofollow" />
 
 		<!-- Favicon -->
-		<link rel="icon" href="../assets/nabla/nabla-4.svg" />
+		<link rel="icon" href="assets/nabla/nabla-4.svg" />
 
 		<!-- Resume Schema Reference for Machine-Readable Tools -->
-		<link rel="alternate" type="application/json" href="./schema.json" title="Resume Schema (JSONResume format)" />
+		<link rel="alternate" type="application/json" href="/cv/schema.json" title="Resume Schema (JSONResume format)" />
 
 		<!-- Font Awesome -->
 		<link
@@ -35,16 +35,16 @@
 		<script src="../theme-toggle.js"></script>
 
 		<!-- Custom CSS -->
-		<link rel="stylesheet" href="../landing-sections.css" />
+		<link rel="stylesheet" href="landing-sections.css" />
 
-		<link rel="stylesheet" href="../wireframe.css" />
-		<link rel="stylesheet" href="../arf.css" />
-		<link rel="stylesheet" href="../theme.css" />
+		<link rel="stylesheet" href="wireframe.css" />
+		<link rel="stylesheet" href="arf.css" />
+		<link rel="stylesheet" href="theme.css" />
 
-		<link rel="stylesheet" href="../style.css" />
+		<link rel="stylesheet" href="style.css" />
 		<!-- Print Styles for PDF Export -->
-		<link rel="stylesheet" href="../print.css" />
-		<link rel="stylesheet" href="../site-content-page.css" />
+		<link rel="stylesheet" href="print.css" />
+		<link rel="stylesheet" href="site-content-page.css" />
 
 		<link rel="stylesheet" href="checkout.css" />
 	</head>
@@ -124,7 +124,7 @@
 				></a>
 			</div>
 			<div class="footer-links">
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/checkout.html
+++ b/public/checkout.html
@@ -7,10 +7,10 @@
 		<meta name="robots" content="noindex, nofollow" />
 
 		<!-- Favicon -->
-		<link rel="icon" href="../assets/nabla/nabla-4.svg" />
+		<link rel="icon" href="assets/nabla/nabla-4.svg" />
 
 		<!-- Resume Schema Reference for Machine-Readable Tools -->
-		<link rel="alternate" type="application/json" href="./schema.json" title="Resume Schema (JSONResume format)" />
+		<link rel="alternate" type="application/json" href="/cv/schema.json" title="Resume Schema (JSONResume format)" />
 
 		<!-- Font Awesome -->
 		<link
@@ -35,16 +35,16 @@
 		<script src="../theme-toggle.js"></script>
 
 		<!-- Custom CSS -->
-		<link rel="stylesheet" href="../landing-sections.css" />
+		<link rel="stylesheet" href="landing-sections.css" />
 
-		<link rel="stylesheet" href="../wireframe.css" />
-		<link rel="stylesheet" href="../arf.css" />
-		<link rel="stylesheet" href="../theme.css" />
+		<link rel="stylesheet" href="wireframe.css" />
+		<link rel="stylesheet" href="arf.css" />
+		<link rel="stylesheet" href="theme.css" />
 
-		<link rel="stylesheet" href="../style.css" />
+		<link rel="stylesheet" href="style.css" />
 		<!-- Print Styles for PDF Export -->
-		<link rel="stylesheet" href="../print.css" />
-		<link rel="stylesheet" href="../site-content-page.css" />
+		<link rel="stylesheet" href="print.css" />
+		<link rel="stylesheet" href="site-content-page.css" />
 
 		<link rel="stylesheet" href="checkout.css" />
 	</head>
@@ -127,7 +127,7 @@
 				></a>
 			</div>
 			<div class="footer-links">
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/ciso.html
+++ b/public/ciso.html
@@ -286,7 +286,7 @@
 				<p>
 					Curated by
 					<a
-						href="/contact"
+						href="/contact.html"
 						style="
 							color: rgba(255, 255, 255, 0.95);
 							text-decoration: underline;
@@ -392,8 +392,8 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing">Pricing</a>
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/pricing.html">Pricing</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/ciso.html
+++ b/public/ciso.html
@@ -392,7 +392,6 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing.html">Pricing</a>
 				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>

--- a/public/contact.html
+++ b/public/contact.html
@@ -564,13 +564,13 @@
 						<a href="/cv/" class="btn btn-primary btn-lg" target="_blank">
 							<i class="fas fa-globe"></i> View Full CV Online
 						</a>
-						<a href="/cv/cv-full.html" class="btn btn-outline-primary" target="_blank">
+						<a href="/cv/cv-full-en.html" class="btn btn-outline-primary" target="_blank">
 							<i class="fas fa-file-alt"></i> Full CV
 						</a>
-						<a href="/cv/cv-medium.html" class="btn btn-outline-primary" target="_blank">
+						<a href="/cv/cv-medium-en.html" class="btn btn-outline-primary" target="_blank">
 							<i class="fas fa-file-alt"></i> Medium CV
 						</a>
-						<a href="/cv/cv-small.html" class="btn btn-outline-primary" target="_blank">
+						<a href="/cv/cv-small-en.html" class="btn btn-outline-primary" target="_blank">
 							<i class="fas fa-file-alt"></i> Short CV
 						</a>
 					</div>
@@ -915,7 +915,7 @@
 			</div>
 
 			<div class="footer-links">
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/policy/legal.html">Legal notices</a>
 			</div>
 
 			<p class="text-md-center mt-3">

--- a/public/ctid.html
+++ b/public/ctid.html
@@ -199,8 +199,8 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing">Pricing</a>
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/pricing.html">Pricing</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/ctid.html
+++ b/public/ctid.html
@@ -199,7 +199,6 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing.html">Pricing</a>
 				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>

--- a/public/cv/index.html
+++ b/public/cv/index.html
@@ -508,21 +508,6 @@
 
                   <section class="cv-section mb-4">
                     <h3 class="h5 border-bottom pb-2 mb-3">
-                      <i class="fa fa-bar-chart text-primary mr-2"></i>Data Driven figures
-                    </h3>
-                    <div class="list-group list-group-flush">
-                      <div class="list-group-item d-flex justify-content-between align-items-center">
-                        <div>
-                          <i class="fa fa-briefcase text-primary mr-2"></i>
-                          <strong>Private legal-tech engagement summary</strong>
-                          <p class="mb-0 text-muted small">High-level outcomes are available on request; detailed metrics remain private.</p>
-                        </div>
-                      </div>
-                    </div>
-                  </section>
-
-                  <section class="cv-section mb-4">
-                    <h3 class="h5 border-bottom pb-2 mb-3">
                       <i class="fa fa-code text-primary mr-2"></i>Old C.V
                     </h3>
                     <div class="list-group-item d-flex justify-content-between align-items-center">

--- a/public/cv/index.html
+++ b/public/cv/index.html
@@ -475,26 +475,26 @@
                           <div class="cv-latex-style-row">
                             <p class="mb-1 text-muted small">Basic style</p>
                             <div class="cv-lang-btns" role="group" aria-label="LaTeX CV basic style by language">
-                              <a href="cv-aandrieu-2026-en.pdf" class="btn btn-sm btn-primary"
+                              <a href="/cv/cv-full-en.html" class="btn btn-sm btn-primary"
                                 target="_blank" download lang="en" aria-label="Download English LaTeX CV PDF, basic style">Download <span class="cv-lang-flag" aria-hidden="true">🇬🇧</span>PDF</a>
-                              <a href="cv-aandrieu-2026-fr.pdf" class="btn btn-sm btn-primary"
+                              <a href="/cv/cv-full-fr.html" class="btn btn-sm btn-primary"
                                 target="_blank" download lang="fr" aria-label="Télécharger le CV LaTeX PDF en français, style basique">Télécharger <span class="cv-lang-flag" aria-hidden="true">🇫🇷</span>PDF</a>
-                              <a href="cv-aandrieu-2026-de.pdf" class="btn btn-sm btn-primary"
+                              <a href="/cv/cv-full-de.html" class="btn btn-sm btn-primary"
                                 target="_blank" download lang="de" aria-label="LaTeX-Lebenslauf als PDF auf Deutsch herunterladen, Basis-Stil">Herunterladen <span class="cv-lang-flag" aria-hidden="true">🇩🇪</span>PDF</a>
-                              <a href="cv-aandrieu-2026-no.pdf" class="btn btn-sm btn-primary"
+                              <a href="/cv/cv-full-no.html" class="btn btn-sm btn-primary"
                                 target="_blank" download lang="no" aria-label="Last ned norsk LaTeX-CV som PDF, grunnleggende stil">Last ned <span class="cv-lang-flag" aria-hidden="true">🇳🇴</span>PDF</a>
                             </div>
                           </div>
                           <div class="cv-latex-style-row">
                             <p class="mb-1 text-muted small">20 Seconds style</p>
                             <div class="cv-lang-btns" role="group" aria-label="LaTeX CV 20 seconds style by language">
-                              <a href="cv-aandrieu-2026-ts-en.pdf" class="btn btn-sm btn-primary"
+                              <a href="/cv/cv-medium-en.html" class="btn btn-sm btn-primary"
                                 target="_blank" download lang="en" aria-label="Download English LaTeX CV PDF, 20 seconds style">Download <span class="cv-lang-flag" aria-hidden="true">🇬🇧</span>PDF</a>
-                              <a href="cv-aandrieu-2026-ts-fr.pdf" class="btn btn-sm btn-primary"
+                              <a href="/cv/cv-medium-fr.html" class="btn btn-sm btn-primary"
                                 target="_blank" download lang="fr" aria-label="Télécharger le CV LaTeX PDF en français, style 20 secondes">Télécharger <span class="cv-lang-flag" aria-hidden="true">🇫🇷</span>PDF</a>
-                              <a href="cv-aandrieu-2026-ts-de.pdf" class="btn btn-sm btn-primary"
+                              <a href="/cv/cv-medium-de.html" class="btn btn-sm btn-primary"
                                 target="_blank" download lang="de" aria-label="LaTeX-Lebenslauf als PDF auf Deutsch herunterladen, 20-Sekunden-Stil">Herunterladen <span class="cv-lang-flag" aria-hidden="true">🇩🇪</span>PDF</a>
-                              <a href="cv-aandrieu-2026-ts-no.pdf" class="btn btn-sm btn-primary"
+                              <a href="/cv/cv-medium-no.html" class="btn btn-sm btn-primary"
                                 target="_blank" download lang="no" aria-label="Last ned norsk LaTeX-CV som PDF, 20 sekunder-stil">Last ned <span class="cv-lang-flag" aria-hidden="true">🇳🇴</span>PDF</a>
                             </div>
                           </div>
@@ -581,7 +581,7 @@
         <a href="https://stackexchange.com/users/4652074/albanandrieu" target="_blank" rel="noopener noreferrer" class="social-link" aria-label="Stack Exchange"><i class="fab fa-stack-exchange"></i></a>
       </div>
 			<div class="footer-links">
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/policy/legal.html">Legal notices</a>
 			</div>
       <p class="text-md-center mt-3">
         <a href="mailto:job@dr-alban.com" class="btn btn-sm btn-outline-secondary"><i class="fas fa-envelope" aria-hidden="true"></i> Email</a>

--- a/public/cv/jusmundi/4-years-review-aandrieu.html
+++ b/public/cv/jusmundi/4-years-review-aandrieu.html
@@ -1,0 +1,212 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Senior Architect Achievements (4-Year Review) | Alban Andrieu</title>
+		<meta
+			name="description"
+			content="NDA-safe four-year summary of senior architect achievements across reliability, security, platform, and delivery."
+		/>
+		<meta
+			name="keywords"
+			content="Alban Andrieu, Senior Architect, DevOps, Platform Engineering, achievements, reliability, security"
+		/>
+		<meta name="author" content="Alban Andrieu" />
+		<meta name="robots" content="noindex, nofollow" />
+		<meta name="referrer" content="always" />
+		<meta name="color-scheme" content="light dark" />
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://dr-alban.com/cv/jusmundi/4-years-review-aandrieu.html" />
+		<meta property="og:title" content="Senior Architect Achievements (4-Year Review)" />
+		<meta
+			property="og:description"
+			content="NDA-safe four-year summary of senior architect achievements with measurable outcomes."
+		/>
+		<meta property="og:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
+		<meta property="twitter:card" content="summary" />
+		<meta property="twitter:url" content="https://dr-alban.com/cv/jusmundi/4-years-review-aandrieu.html" />
+		<meta property="twitter:title" content="Senior Architect Achievements (4-Year Review)" />
+		<meta
+			property="twitter:description"
+			content="NDA-safe four-year summary of senior architect achievements with measurable outcomes."
+		/>
+		<meta property="twitter:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
+		<link rel="canonical" href="https://dr-alban.com/cv/jusmundi/4-years-review-aandrieu.html" />
+		<link rel="icon" href="../../assets/nabla/nabla-4.svg" />
+		<link href="/assets/fontawesome/css/fontawesome.css" rel="stylesheet" />
+		<link href="/assets/fontawesome/css/brands.css" rel="stylesheet" />
+		<link href="/assets/fontawesome/css/solid.css" rel="stylesheet" />
+		<link rel="stylesheet" href="../../landing-sections.css" />
+		<link rel="stylesheet" href="../../wireframe.css" />
+		<link rel="stylesheet" href="../../theme.css" />
+		<link rel="stylesheet" href="../../style.css" />
+		<link rel="stylesheet" href="../../print.css" />
+		<link rel="stylesheet" href="../cv-theme.css" />
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.1/css/bootstrap.min.css"
+			integrity="sha512-siwe/oXMhSjGCwLn+scraPOWrJxHlUgMBMZXdPe2Tnk3I0x3ESCoLz7WZ5NTH6SZrywMY+PB1cjyqJ5jAluCOg=="
+			crossorigin="anonymous"
+			referrerpolicy="no-referrer"
+		/>
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.9.1/font/bootstrap-icons.min.css"
+			integrity="sha512-5PV92qsds/16vyYIJo3T/As4m2d8b6oWYfoqV+vtizRB6KhF1F9kYzWzQmsO6T3z3QG2Xdhrx7FQ+5R1LiQdUA=="
+			crossorigin="anonymous"
+			referrerpolicy="no-referrer"
+		/>
+		<link rel="stylesheet" href="../../site-content-page.css" />
+		<link rel="stylesheet" href="jusmundi.css" />
+		<script src="../../theme-toggle.js"></script>
+		<script src="../../site-google-translate.js" defer></script>
+		<script src="../../site-analytics.js"></script>
+	</head>
+	<body class="site-content-page jusmundi-page jusmundi-landing-page page-dark">
+		<a name="top"></a>
+		<a href="#main-content" class="skip-link">Skip to main content</a>
+		<nav class="page-nav container py-3 d-flex flex-wrap align-items-center gap-2" aria-label="Breadcrumb">
+			<a href="/cv/jusmundi" class="text-decoration-none" aria-label="Back to Jusmundi index">
+				<span aria-hidden="true">←</span> Jusmundi
+			</a>
+			<span class="opacity-75" aria-hidden="true">·</span>
+			<a href="/cv" class="text-decoration-none" aria-label="Back to CV index">CV index</a>
+		</nav>
+
+		<main id="main-content" role="main" class="container py-4 pb-5">
+			<section class="hero-section jusmundi-hero-compact" aria-labelledby="hero-heading">
+				<div class="hero-content">
+					<h1 class="hero-title" id="hero-heading">Senior Architect Achievements — 4-Year Review</h1>
+					<p class="hero-subtitle">Execution impact across platform, security, reliability, and delivery leadership</p>
+				</div>
+			</section>
+
+			<section class="proof-section jusmundi-landing-content" aria-labelledby="exec-heading">
+				<h2 class="section-title" id="exec-heading">Executive summary</h2>
+				<div class="service-card jusmundi-service-card-wide">
+					<p>
+						Over four years, I delivered a sustained architecture and DevOps transformation agenda focused on business
+						continuity, faster delivery, and lower operational risk.
+					</p>
+					<ul class="summary-list">
+						<li>~90% reduction in manual configuration errors through infrastructure as code and automation.</li>
+						<li>~60% alert-noise reduction through improved observability design and incident signal quality.</li>
+						<li>Critical incident recovery time reduced by around 50% through runbooks and platform standards.</li>
+						<li>Security remediation velocity improved by over 50% with embedded controls in delivery workflows.</li>
+					</ul>
+				</div>
+			</section>
+
+			<section class="services-section jusmundi-landing-content" aria-labelledby="pillars-heading">
+				<h2 class="section-title" id="pillars-heading">Strategic contribution pillars</h2>
+				<div class="services-grid">
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-sitemap"></i></div>
+						<h3>Architecture and platform governance</h3>
+						<p class="service-lead">
+							Established scalable operating models, reusable patterns, and review practices across critical systems.
+						</p>
+					</div>
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-shield-halved"></i></div>
+						<h3>Security engineering integration</h3>
+						<p class="service-lead">
+							Integrated identity, access, and vulnerability management into delivery to reduce exposure windows.
+						</p>
+					</div>
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-heart-pulse"></i></div>
+						<h3>Reliability and incident readiness</h3>
+						<p class="service-lead">
+							Improved system resilience through proactive monitoring, runbook maturity, and response optimization.
+						</p>
+					</div>
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-rocket"></i></div>
+						<h3>Delivery acceleration</h3>
+						<p class="service-lead">
+							Strengthened CI/CD and environment consistency to raise deployment confidence and team velocity.
+						</p>
+					</div>
+				</div>
+			</section>
+
+			<section class="proof-section jusmundi-landing-content" aria-labelledby="portfolio-heading">
+				<h2 class="section-title" id="portfolio-heading">Project portfolio (NDA-safe)</h2>
+				<div class="service-card jusmundi-service-card-wide">
+					<h3>Representative workstreams</h3>
+					<ul class="service-bullets">
+						<li>Identity and access modernization programs for secure user and service interactions.</li>
+						<li>Platform reliability initiatives combining observability upgrades and operational playbooks.</li>
+						<li>Infrastructure lifecycle optimization across cost, performance, and resilience dimensions.</li>
+						<li>Delivery pipeline hardening to increase release quality while reducing manual overhead.</li>
+						<li>Cross-team architecture enablement for product scale and predictable execution.</li>
+					</ul>
+					<p>
+						Each workstream was delivered with strict attention to confidentiality and risk management, while preserving
+						focus on measurable outcomes.
+					</p>
+				</div>
+			</section>
+		</main>
+
+		<footer class="footer" role="contentinfo">
+			<div class="social-links">
+				<a
+					href="https://www.linkedin.com/in/nabla"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="LinkedIn"
+					><i class="fab fa-linkedin-in"></i
+				></a>
+				<a
+					href="https://calendly.com/alban-andrieu"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="Calendly"
+					><i class="fa fa-calendar-plus"></i
+				></a>
+				<a
+					href="https://github.com/AlbanAndrieu"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="GitHub"
+					><i class="fab fa-github"></i
+				></a>
+				<a
+					href="https://hub.docker.com/u/nabla"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="Docker Hub"
+					><i class="fab fa-docker"></i
+				></a>
+				<a
+					href="https://stackexchange.com/users/4652074/albanandrieu"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="Stack Exchange"
+					><i class="fab fa-stack-exchange"></i
+				></a>
+			</div>
+			<div class="footer-links">
+				<a href="/pricing">Pricing</a>
+				<a href="/policy/legal">Legal notices</a>
+				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
+			</div>
+			<p class="text-md-center mt-3">
+				<a href="/cv/jusmundi" class="btn btn-sm btn-outline-secondary">Jusmundi index</a>
+				<a href="/cv" class="btn btn-sm btn-outline-secondary ms-2">CV index</a>
+				<a href="#top" class="btn btn-sm btn-outline-secondary ms-2" aria-label="Back to top of page">Back to top</a>
+			</p>
+			<p class="text-muted small mt-2">NDA-safe senior architect performance summary.</p>
+			<p class="footer-copyright"></p>
+		</footer>
+		<script src="../../site-widgets.js" defer data-print-pdf data-coffee-fab></script>
+	</body>
+</html>

--- a/public/cv/jusmundi/4-years-review-aandrieu.html
+++ b/public/cv/jusmundi/4-years-review-aandrieu.html
@@ -279,7 +279,6 @@
 				></a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing.html">Pricing</a>
 				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>

--- a/public/cv/jusmundi/4-years-review-aandrieu.html
+++ b/public/cv/jusmundi/4-years-review-aandrieu.html
@@ -67,11 +67,11 @@
 		<a name="top"></a>
 		<a href="#main-content" class="skip-link">Skip to main content</a>
 		<nav class="page-nav container py-3 d-flex flex-wrap align-items-center gap-2" aria-label="Breadcrumb">
-			<a href="/cv/jusmundi" class="text-decoration-none" aria-label="Back to Jusmundi index">
-				<span aria-hidden="true">←</span> Jusmundi
+			<a href="/cv/jusmundi" class="text-decoration-none" aria-label="Back to JusMundi index">
+				<span aria-hidden="true">←</span> JusMundi
 			</a>
 			<span class="opacity-75" aria-hidden="true">·</span>
-			<a href="/cv" class="text-decoration-none" aria-label="Back to CV index">CV index</a>
+			<a href="/cv" class="text-decoration-none" aria-label="Back to CV index">Return to CV</a>
 		</nav>
 
 		<main id="main-content" role="main" class="container py-4 pb-5">
@@ -283,9 +283,8 @@
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">
-				<a href="/cv/jusmundi" class="btn btn-sm btn-outline-secondary">Jusmundi index</a>
-				<a href="/cv" class="btn btn-sm btn-outline-secondary ms-2">CV index</a>
-				<a href="#top" class="btn btn-sm btn-outline-secondary ms-2" aria-label="Back to top of page">Back to top</a>
+				<a href="/cv/jusmundi" class="btn btn-sm btn-outline-secondary">Return to JusMundi index</a>
+				<a href="/cv" class="btn btn-sm btn-outline-secondary ms-2">Return to CV</a>
 			</p>
 			<p class="text-muted small mt-2">Senior architect performance summary.</p>
 			<p class="footer-copyright"></p>

--- a/public/cv/jusmundi/4-years-review-aandrieu.html
+++ b/public/cv/jusmundi/4-years-review-aandrieu.html
@@ -279,8 +279,8 @@
 				></a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing">Pricing</a>
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/pricing.html">Pricing</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/cv/jusmundi/4-years-review-aandrieu.html
+++ b/public/cv/jusmundi/4-years-review-aandrieu.html
@@ -61,7 +61,7 @@
 		<link rel="stylesheet" href="jusmundi.css" />
 		<script src="../../theme-toggle.js"></script>
 		<script src="../../site-google-translate.js" defer></script>
-		<script src="../../site-analytics.js"></script>
+		<script src="../../site-analytics.js" defer></script>
 	</head>
 	<body class="site-content-page jusmundi-page jusmundi-landing-page page-dark">
 		<a name="top"></a>

--- a/public/cv/jusmundi/4-years-review-aandrieu.html
+++ b/public/cv/jusmundi/4-years-review-aandrieu.html
@@ -6,7 +6,7 @@
 		<title>Senior Architect Achievements (4-Year Review) | Alban Andrieu</title>
 		<meta
 			name="description"
-			content="NDA-safe four-year summary of senior architect achievements across reliability, security, platform, and delivery."
+			content="Four-year summary of senior architect achievements across reliability, security, platform, and delivery."
 		/>
 		<meta
 			name="keywords"
@@ -21,7 +21,7 @@
 		<meta property="og:title" content="Senior Architect Achievements (4-Year Review)" />
 		<meta
 			property="og:description"
-			content="NDA-safe four-year summary of senior architect achievements with measurable outcomes."
+			content="Four-year summary of senior architect achievements with measurable outcomes."
 		/>
 		<meta property="og:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
 		<meta property="twitter:card" content="summary" />
@@ -29,7 +29,7 @@
 		<meta property="twitter:title" content="Senior Architect Achievements (4-Year Review)" />
 		<meta
 			property="twitter:description"
-			content="NDA-safe four-year summary of senior architect achievements with measurable outcomes."
+			content="Four-year summary of senior architect achievements with measurable outcomes."
 		/>
 		<meta property="twitter:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
 		<link rel="canonical" href="https://dr-alban.com/cv/jusmundi/4-years-review-aandrieu.html" />
@@ -288,7 +288,7 @@
 				<a href="/cv" class="btn btn-sm btn-outline-secondary ms-2">CV index</a>
 				<a href="#top" class="btn btn-sm btn-outline-secondary ms-2" aria-label="Back to top of page">Back to top</a>
 			</p>
-			<p class="text-muted small mt-2">NDA-safe senior architect performance summary.</p>
+			<p class="text-muted small mt-2">Senior architect performance summary.</p>
 			<p class="footer-copyright"></p>
 		</footer>
 		<script src="../../site-widgets.js" defer data-print-pdf data-coffee-fab></script>

--- a/public/cv/jusmundi/4-years-review-aandrieu.html
+++ b/public/cv/jusmundi/4-years-review-aandrieu.html
@@ -89,64 +89,148 @@
 						Over four years, I delivered a sustained architecture and DevOps transformation agenda focused on business
 						continuity, faster delivery, and lower operational risk.
 					</p>
-					<ul class="summary-list">
-						<li>~90% reduction in manual configuration errors through infrastructure as code and automation.</li>
-						<li>~60% alert-noise reduction through improved observability design and incident signal quality.</li>
-						<li>Critical incident recovery time reduced by around 50% through runbooks and platform standards.</li>
-						<li>Security remediation velocity improved by over 50% with embedded controls in delivery workflows.</li>
-					</ul>
+					<div class="jusmundi-table-card">
+						<table class="kpi-table" role="table" aria-label="Task completion by year">
+							<thead>
+								<tr>
+									<th scope="col">Year</th>
+									<th scope="col">Tasks completed</th>
+									<th scope="col">YoY growth</th>
+									<th scope="col">Key focus areas</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td><strong>2022</strong></td>
+									<td>~50 tasks</td>
+									<td>Baseline</td>
+									<td>Foundation building, CI/CD modernization, platform baseline</td>
+								</tr>
+								<tr>
+									<td><strong>2023</strong></td>
+									<td>~60 tasks</td>
+									<td>+20%</td>
+									<td>Observability stack, reliability, and service instrumentation</td>
+								</tr>
+								<tr>
+									<td><strong>2024</strong></td>
+									<td>~65 tasks</td>
+									<td>+8%</td>
+									<td>Security hardening, performance, and architecture stabilization</td>
+								</tr>
+								<tr>
+									<td><strong>2025</strong></td>
+									<td><strong>150+ tasks</strong></td>
+									<td>+131%</td>
+									<td>Infrastructure v2, US hosting, Kubernetes migration</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+					<p class="mt-3 mb-0"><strong>Total: 325+ tasks completed over 4 years</strong></p>
 				</div>
 			</section>
 
 			<section class="services-section jusmundi-landing-content" aria-labelledby="pillars-heading">
-				<h2 class="section-title" id="pillars-heading">Strategic contribution pillars</h2>
+				<h2 class="section-title" id="pillars-heading">Key achievements by strategic theme</h2>
 				<div class="services-grid">
 					<div class="service-card">
 						<div class="service-icon" aria-hidden="true"><i class="fas fa-sitemap"></i></div>
-						<h3>Architecture and platform governance</h3>
+						<h3>1. Infrastructure modernization and cloud platform</h3>
 						<p class="service-lead">
-							Established scalable operating models, reusable patterns, and review practices across critical systems.
+							Platform evolution from baseline operations to multi-region architecture support (EU/US), with stronger
+							governance and delivery standards.
 						</p>
 					</div>
 					<div class="service-card">
 						<div class="service-icon" aria-hidden="true"><i class="fas fa-shield-halved"></i></div>
-						<h3>Security engineering integration</h3>
+						<h3>2. Security and compliance execution</h3>
 						<p class="service-lead">
-							Integrated identity, access, and vulnerability management into delivery to reduce exposure windows.
+							Integrated identity, access, anti-abuse, and remediation workflows directly into engineering delivery.
 						</p>
 					</div>
 					<div class="service-card">
-						<div class="service-icon" aria-hidden="true"><i class="fas fa-heart-pulse"></i></div>
-						<h3>Reliability and incident readiness</h3>
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-database"></i></div>
+						<h3>3. Database and data-layer excellence</h3>
 						<p class="service-lead">
-							Improved system resilience through proactive monitoring, runbook maturity, and response optimization.
+							PostgreSQL tuning, stability improvements, and repeated resolution of high-severity operational incidents.
 						</p>
 					</div>
 					<div class="service-card">
 						<div class="service-icon" aria-hidden="true"><i class="fas fa-rocket"></i></div>
-						<h3>Delivery acceleration</h3>
+						<h3>4. CI/CD and delivery excellence</h3>
 						<p class="service-lead">
 							Strengthened CI/CD and environment consistency to raise deployment confidence and team velocity.
+						</p>
+					</div>
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-robot"></i></div>
+						<h3>5. AI/ML platform enablement</h3>
+						<p class="service-lead">
+							Platform support for AI-focused workloads, search infrastructure, and production-readiness controls.
+						</p>
+					</div>
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-chart-line"></i></div>
+						<h3>6. Observability and site reliability</h3>
+						<p class="service-lead">
+							Metrics, logs, traces, and runbooks used to improve MTTR and reduce operational noise.
 						</p>
 					</div>
 				</div>
 			</section>
 
-			<section class="proof-section jusmundi-landing-content" aria-labelledby="portfolio-heading">
-				<h2 class="section-title" id="portfolio-heading">Project portfolio (NDA-safe)</h2>
+			<section class="proof-section jusmundi-landing-content" aria-labelledby="standout-heading">
+				<h2 class="section-title" id="standout-heading">Standout technical achievements</h2>
 				<div class="service-card jusmundi-service-card-wide">
-					<h3>Representative workstreams</h3>
-					<ul class="service-bullets">
-						<li>Identity and access modernization programs for secure user and service interactions.</li>
-						<li>Platform reliability initiatives combining observability upgrades and operational playbooks.</li>
-						<li>Infrastructure lifecycle optimization across cost, performance, and resilience dimensions.</li>
-						<li>Delivery pipeline hardening to increase release quality while reducing manual overhead.</li>
-						<li>Cross-team architecture enablement for product scale and predictable execution.</li>
+					<ul class="summary-list">
+						<li>
+							<strong>Anti-scraping and abuse protection</strong>: significantly reduced abusive traffic while preserving
+							search visibility and user experience.
+						</li>
+						<li>
+							<strong>Observability platform maturity</strong>: reduced MTTR from hours to minutes through better signal
+							quality and runbooks.
+						</li>
+						<li>
+							<strong>Authentication modernization</strong>: large-scale identity upgrades with stronger resilience and
+							security controls.
+						</li>
+						<li>
+							<strong>Infrastructure as code adoption</strong>: major reduction in manual configuration errors and drift.
+						</li>
 					</ul>
-					<p>
-						Each workstream was delivered with strict attention to confidentiality and risk management, while preserving
-						focus on measurable outcomes.
-					</p>
+				</div>
+			</section>
+
+			<section class="services-section jusmundi-landing-content" aria-labelledby="portfolio-heading">
+				<h2 class="section-title" id="portfolio-heading">Major projects and tasks delivered</h2>
+				<div class="service-card jusmundi-service-card-wide">
+					<ul class="service-bullets">
+						<li>Infrastructure v2 assessment and migration preparation, including EU/US operating constraints.</li>
+						<li>US hosting rollout planning and execution across networking, DNS, and platform layers.</li>
+						<li>Kubernetes migration path design from existing orchestration baseline.</li>
+						<li>Identity and access hardening with major upgrade cycles and production stabilization.</li>
+						<li>Anti-abuse and WAF program rollout with production monitoring and iterative tuning.</li>
+						<li>PostgreSQL performance and reliability work, including recurring critical-incident recovery.</li>
+						<li>Observability platform improvements across metrics, logs, tracing, dashboards, and alert quality.</li>
+						<li>CI/CD reliability work: pipeline optimization, security checks, and deployment guardrails.</li>
+						<li>AI-platform support projects around indexing, compute enablement, and service reliability.</li>
+						<li>Documentation and RFC work to scale architecture patterns and operating discipline.</li>
+					</ul>
+				</div>
+			</section>
+
+			<section class="proof-section jusmundi-landing-content" aria-labelledby="numbers-heading">
+				<h2 class="section-title" id="numbers-heading">Performance summary by numbers</h2>
+				<div class="service-card jusmundi-service-card-wide">
+					<ul class="summary-list">
+						<li><strong>325+ tasks</strong> completed over 4 years</li>
+						<li><strong>20+ critical incidents</strong> resolved with minimal downtime</li>
+						<li><strong>8 major strategic projects</strong> delivered in the latest year</li>
+						<li><strong>~90% reduction</strong> in manual configuration errors via IaC patterns</li>
+						<li><strong>~60% reduction</strong> in alert noise</li>
+					</ul>
 				</div>
 			</section>
 		</main>

--- a/public/cv/jusmundi/4-years-review-jusmundi.html
+++ b/public/cv/jusmundi/4-years-review-jusmundi.html
@@ -218,7 +218,6 @@
 				></a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing.html">Pricing</a>
 				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>

--- a/public/cv/jusmundi/4-years-review-jusmundi.html
+++ b/public/cv/jusmundi/4-years-review-jusmundi.html
@@ -1,0 +1,235 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>JusMundi History &amp; Positioning | Alban Andrieu</title>
+		<meta
+			name="description"
+			content="Public and NDA-safe overview of JusMundi history, product evolution, and strategic positioning."
+		/>
+		<meta name="keywords" content="Alban Andrieu, JusMundi, legal intelligence, AI, history, positioning" />
+		<meta name="author" content="Alban Andrieu" />
+		<meta name="robots" content="noindex, nofollow" />
+		<meta name="referrer" content="always" />
+		<meta name="color-scheme" content="light dark" />
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://dr-alban.com/cv/jusmundi/4-years-review-jusmundi.html" />
+		<meta property="og:title" content="JusMundi History &amp; Positioning | Alban Andrieu" />
+		<meta
+			property="og:description"
+			content="Public and NDA-safe overview of JusMundi history, product evolution, and strategic positioning."
+		/>
+		<meta property="og:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
+		<meta property="twitter:card" content="summary" />
+		<meta property="twitter:url" content="https://dr-alban.com/cv/jusmundi/4-years-review-jusmundi.html" />
+		<meta property="twitter:title" content="JusMundi History &amp; Positioning" />
+		<meta
+			property="twitter:description"
+			content="NDA-safe company narrative focused on mission, product evolution, and execution outcomes."
+		/>
+		<meta property="twitter:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
+		<link rel="canonical" href="https://dr-alban.com/cv/jusmundi/4-years-review-jusmundi.html" />
+		<link rel="icon" href="../../assets/nabla/nabla-4.svg" />
+		<link rel="stylesheet" href="../../landing-sections.css" />
+		<link rel="stylesheet" href="../../wireframe.css" />
+		<link rel="stylesheet" href="../../theme.css" />
+		<link rel="stylesheet" href="../../style.css" />
+		<link rel="stylesheet" href="../../print.css" />
+		<link rel="stylesheet" href="../cv-theme.css" />
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.1/css/bootstrap.min.css"
+			integrity="sha512-siwe/oXMhSjGCwLn+scraPOWrJxHlUgMBMZXdPe2Tnk3I0x3ESCoLz7WZ5NTH6SZrywMY+PB1cjyqJ5jAluCOg=="
+			crossorigin="anonymous"
+			referrerpolicy="no-referrer"
+		/>
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.9.1/font/bootstrap-icons.min.css"
+			integrity="sha512-5PV92qsds/16vyYIJo3T/As4m2d8b6oWYfoqV+vtizRB6KhF1F9kYzWzQmsO6T3z3QG2Xdhrx7FQ+5R1LiQdUA=="
+			crossorigin="anonymous"
+			referrerpolicy="no-referrer"
+		/>
+		<link rel="stylesheet" href="../../site-content-page.css" />
+		<link rel="stylesheet" href="jusmundi.css" />
+		<link href="/assets/fontawesome/css/fontawesome.css" rel="stylesheet" />
+		<link href="/assets/fontawesome/css/brands.css" rel="stylesheet" />
+		<link href="/assets/fontawesome/css/solid.css" rel="stylesheet" />
+		<script src="../../theme-toggle.js"></script>
+		<script src="../../site-google-translate.js" defer></script>
+		<script src="../../site-analytics.js"></script>
+	</head>
+	<body class="site-content-page jusmundi-page jusmundi-landing-page page-dark">
+		<a name="top"></a>
+		<a href="#main-content" class="skip-link">Skip to main content</a>
+
+		<nav class="page-nav container py-3 d-flex flex-wrap align-items-center gap-2" aria-label="Breadcrumb">
+			<a href="/cv/jusmundi" class="text-decoration-none" aria-label="Back to Jusmundi index">
+				<span aria-hidden="true">←</span> Jusmundi
+			</a>
+			<span class="opacity-75" aria-hidden="true">·</span>
+			<a href="/cv" class="text-decoration-none" aria-label="Back to CV index">CV index</a>
+		</nav>
+
+		<main id="main-content" role="main" class="container py-4 pb-5">
+			<section class="hero-section jusmundi-hero-compact" aria-labelledby="hero-heading">
+				<div class="hero-content">
+					<h1 class="hero-title" id="hero-heading">JusMundi — History and Strategic Positioning</h1>
+					<p class="hero-subtitle">Public-facing context to support a senior architect profile</p>
+				</div>
+			</section>
+
+			<section class="proof-section jusmundi-landing-content" aria-labelledby="history-heading">
+				<h2 class="section-title" id="history-heading">History at a glance</h2>
+				<div class="service-card jusmundi-service-card-wide">
+					<p>
+						JusMundi started in 2019 with a legal intelligence mission focused on international law and arbitration. The
+						platform then evolved into a broader product ecosystem combining legal content, structured research, and
+						AI-assisted workflows.
+					</p>
+					<p>
+						The company narrative is consistent: increase trust, improve legal research efficiency, and scale operations
+						without compromising quality or security expectations.
+					</p>
+				</div>
+			</section>
+
+			<section class="services-section jusmundi-landing-content" aria-labelledby="timeline-heading">
+				<h2 class="section-title" id="timeline-heading">Evolution over four years</h2>
+				<div class="service-card jusmundi-service-card-wide">
+					<div class="jusmundi-table-card">
+						<table class="kpi-table" role="table" aria-label="JusMundi evolution timeline">
+							<thead>
+								<tr>
+									<th scope="col">Period</th>
+									<th scope="col">Main evolution</th>
+									<th scope="col">Operational implication</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Foundation</td>
+									<td>Legal intelligence platform consolidation</td>
+									<td>Core reliability and delivery foundations</td>
+								</tr>
+								<tr>
+									<td>Expansion</td>
+									<td>Multi-product roadmap acceleration</td>
+									<td>Cross-team scaling and stronger platform governance</td>
+								</tr>
+								<tr>
+									<td>AI integration</td>
+									<td>AI-assisted research and drafting capabilities</td>
+									<td>Higher security and observability requirements</td>
+								</tr>
+								<tr>
+									<td>Maturity</td>
+									<td>Global operations and execution discipline</td>
+									<td>Architecture leadership with measurable outcomes</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</section>
+
+			<section class="proof-section jusmundi-landing-content" aria-labelledby="positioning-heading">
+				<h2 class="section-title" id="positioning-heading">Market positioning (NDA-safe)</h2>
+				<div class="services-grid">
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-gavel"></i></div>
+						<h3>Specialized legal domain</h3>
+						<p class="service-lead">
+							Positioned on high-value legal research and analysis, with a focus on domain-specific quality.
+						</p>
+					</div>
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-microchip"></i></div>
+						<h3>AI-enabled product direction</h3>
+						<p class="service-lead">
+							Practical AI features integrated into user workflows, with accountability and trust as design principles.
+						</p>
+					</div>
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-shield-halved"></i></div>
+						<h3>Operational trust model</h3>
+						<p class="service-lead">
+							Security, compliance, and reliability treated as product enablers rather than isolated controls.
+						</p>
+					</div>
+				</div>
+			</section>
+
+			<section class="services-section jusmundi-landing-content" aria-labelledby="impact-heading">
+				<h2 class="section-title" id="impact-heading">Execution outcomes used in my architect narrative</h2>
+				<div class="service-card jusmundi-service-card-wide">
+					<ul class="summary-list">
+						<li>Operational risk reduction through standardized platform controls and architecture governance.</li>
+						<li>Delivery acceleration supported by automation and cross-team engineering enablement.</li>
+						<li>Improved platform resilience with faster incident recovery and clearer ownership boundaries.</li>
+						<li>Higher security maturity with better remediation cadence and stronger access controls.</li>
+					</ul>
+				</div>
+			</section>
+		</main>
+
+		<footer class="footer" role="contentinfo">
+			<div class="social-links">
+				<a
+					href="https://www.linkedin.com/in/nabla"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="LinkedIn"
+					><i class="fab fa-linkedin-in"></i
+				></a>
+				<a
+					href="https://calendly.com/alban-andrieu"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="Calendly"
+					><i class="fa fa-calendar-plus"></i
+				></a>
+				<a
+					href="https://github.com/AlbanAndrieu"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="GitHub"
+					><i class="fab fa-github"></i
+				></a>
+				<a
+					href="https://hub.docker.com/u/nabla"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="Docker Hub"
+					><i class="fab fa-docker"></i
+				></a>
+				<a
+					href="https://stackexchange.com/users/4652074/albanandrieu"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="Stack Exchange"
+					><i class="fab fa-stack-exchange"></i
+				></a>
+			</div>
+			<div class="footer-links">
+				<a href="/pricing">Pricing</a>
+				<a href="/policy/legal">Legal notices</a>
+				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
+			</div>
+			<p class="text-md-center mt-3">
+				<a href="/cv/jusmundi" class="btn btn-sm btn-outline-secondary">Jusmundi index</a>
+				<a href="/cv" class="btn btn-sm btn-outline-secondary ms-2">CV index</a>
+				<a href="#top" class="btn btn-sm btn-outline-secondary ms-2" aria-label="Back to top of page">Back to top</a>
+			</p>
+			<p class="text-muted small mt-2">Public and NDA-safe company history summary.</p>
+			<p class="footer-copyright"></p>
+		</footer>
+		<script src="../../site-widgets.js" defer data-print-pdf data-coffee-fab></script>
+	</body>
+</html>

--- a/public/cv/jusmundi/4-years-review-jusmundi.html
+++ b/public/cv/jusmundi/4-years-review-jusmundi.html
@@ -65,11 +65,11 @@
 		<a href="#main-content" class="skip-link">Skip to main content</a>
 
 		<nav class="page-nav container py-3 d-flex flex-wrap align-items-center gap-2" aria-label="Breadcrumb">
-			<a href="/cv/jusmundi" class="text-decoration-none" aria-label="Back to Jusmundi index">
-				<span aria-hidden="true">←</span> Jusmundi
+			<a href="/cv/jusmundi" class="text-decoration-none" aria-label="Back to JusMundi index">
+				<span aria-hidden="true">←</span> JusMundi
 			</a>
 			<span class="opacity-75" aria-hidden="true">·</span>
-			<a href="/cv" class="text-decoration-none" aria-label="Back to CV index">CV index</a>
+			<a href="/cv" class="text-decoration-none" aria-label="Back to CV index">Return to CV</a>
 		</nav>
 
 		<main id="main-content" role="main" class="container py-4 pb-5">
@@ -222,9 +222,8 @@
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">
-				<a href="/cv/jusmundi" class="btn btn-sm btn-outline-secondary">Jusmundi index</a>
-				<a href="/cv" class="btn btn-sm btn-outline-secondary ms-2">CV index</a>
-				<a href="#top" class="btn btn-sm btn-outline-secondary ms-2" aria-label="Back to top of page">Back to top</a>
+				<a href="/cv/jusmundi" class="btn btn-sm btn-outline-secondary">Return to JusMundi index</a>
+				<a href="/cv" class="btn btn-sm btn-outline-secondary ms-2">Return to CV</a>
 			</p>
 			<p class="text-muted small mt-2">Public company history summary.</p>
 			<p class="footer-copyright"></p>

--- a/public/cv/jusmundi/4-years-review-jusmundi.html
+++ b/public/cv/jusmundi/4-years-review-jusmundi.html
@@ -218,8 +218,8 @@
 				></a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing">Pricing</a>
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/pricing.html">Pricing</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/cv/jusmundi/4-years-review-jusmundi.html
+++ b/public/cv/jusmundi/4-years-review-jusmundi.html
@@ -6,7 +6,7 @@
 		<title>JusMundi History &amp; Positioning | Alban Andrieu</title>
 		<meta
 			name="description"
-			content="Public and NDA-safe overview of JusMundi history, product evolution, and strategic positioning."
+			content="Public overview of JusMundi history, product evolution, and strategic positioning."
 		/>
 		<meta name="keywords" content="Alban Andrieu, JusMundi, legal intelligence, AI, history, positioning" />
 		<meta name="author" content="Alban Andrieu" />
@@ -18,7 +18,7 @@
 		<meta property="og:title" content="JusMundi History &amp; Positioning | Alban Andrieu" />
 		<meta
 			property="og:description"
-			content="Public and NDA-safe overview of JusMundi history, product evolution, and strategic positioning."
+			content="Public overview of JusMundi history, product evolution, and strategic positioning."
 		/>
 		<meta property="og:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
 		<meta property="twitter:card" content="summary" />
@@ -26,7 +26,7 @@
 		<meta property="twitter:title" content="JusMundi History &amp; Positioning" />
 		<meta
 			property="twitter:description"
-			content="NDA-safe company narrative focused on mission, product evolution, and execution outcomes."
+			content="Company narrative focused on mission, product evolution, and execution outcomes."
 		/>
 		<meta property="twitter:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
 		<link rel="canonical" href="https://dr-alban.com/cv/jusmundi/4-years-review-jusmundi.html" />
@@ -135,7 +135,7 @@
 			</section>
 
 			<section class="proof-section jusmundi-landing-content" aria-labelledby="positioning-heading">
-				<h2 class="section-title" id="positioning-heading">Market positioning (NDA-safe)</h2>
+				<h2 class="section-title" id="positioning-heading">Market positioning</h2>
 				<div class="services-grid">
 					<div class="service-card">
 						<div class="service-icon" aria-hidden="true"><i class="fas fa-gavel"></i></div>
@@ -227,7 +227,7 @@
 				<a href="/cv" class="btn btn-sm btn-outline-secondary ms-2">CV index</a>
 				<a href="#top" class="btn btn-sm btn-outline-secondary ms-2" aria-label="Back to top of page">Back to top</a>
 			</p>
-			<p class="text-muted small mt-2">Public and NDA-safe company history summary.</p>
+			<p class="text-muted small mt-2">Public company history summary.</p>
 			<p class="footer-copyright"></p>
 		</footer>
 		<script src="../../site-widgets.js" defer data-print-pdf data-coffee-fab></script>

--- a/public/cv/jusmundi/index.html
+++ b/public/cv/jusmundi/index.html
@@ -285,7 +285,6 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing.html">Pricing</a>
 				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>

--- a/public/cv/jusmundi/index.html
+++ b/public/cv/jusmundi/index.html
@@ -196,36 +196,6 @@
 				</div>
 			</section>
 
-			<section class="proof-section jusmundi-landing-content" aria-labelledby="documents-heading">
-				<h2 class="section-title" id="documents-heading">Detailed pages</h2>
-				<div class="services-grid">
-					<a href="4-years-review-jusmundi.html" class="service-card jusmundi-doc-card">
-						<div class="service-icon" aria-hidden="true"><i class="fas fa-building"></i></div>
-						<h3>Company history and positioning</h3>
-						<p class="service-lead">Public overview of mission, product evolution, and strategic direction.</p>
-					</a>
-					<a href="structure.html" class="service-card jusmundi-doc-card">
-						<div class="service-icon" aria-hidden="true"><i class="fas fa-users"></i></div>
-						<h3>Team composition (public figures)</h3>
-						<p class="service-lead">Team size and percentage distribution relevant to DevOps collaboration.</p>
-					</a>
-					<a href="infrastructure-costs.html" class="service-card jusmundi-doc-card">
-						<div class="service-icon" aria-hidden="true"><i class="fas fa-server"></i></div>
-						<h3>Infrastructure overview</h3>
-						<p class="service-lead">NDA-safe architecture scope, reliability model, and governance approach.</p>
-					</a>
-					<a href="4-years-review-aandrieu.html" class="service-card jusmundi-doc-card">
-						<div class="service-icon" aria-hidden="true"><i class="fas fa-user-tie"></i></div>
-						<h3>Senior architect achievements</h3>
-						<p class="service-lead">Four-year project portfolio and measurable outcomes.</p>
-					</a>
-					<a href="yearly-review-2025-aandrieu.html" class="service-card jusmundi-doc-card">
-						<div class="service-icon" aria-hidden="true"><i class="fas fa-calendar-check"></i></div>
-						<h3>Most recent yearly focus</h3>
-						<p class="service-lead">Latest execution highlights and leadership priorities.</p>
-					</a>
-				</div>
-			</section>
 		</main>
 
 		<footer class="footer" role="contentinfo">

--- a/public/cv/jusmundi/index.html
+++ b/public/cv/jusmundi/index.html
@@ -6,7 +6,7 @@
 		<title>JusMundi — Senior Architect &amp; DevOps Impact | Alban Andrieu</title>
 		<meta
 			name="description"
-			content="NDA-safe 4-year JusMundi summary: company history, team context, infrastructure scope, and senior architect achievements."
+			content="4-year JusMundi summary: company history, team context, infrastructure scope, and senior architect achievements."
 		/>
 		<meta
 			name="keywords"
@@ -22,7 +22,7 @@
 		<meta property="og:title" content="JusMundi — Senior Architect &amp; DevOps Impact | Alban Andrieu" />
 		<meta
 			property="og:description"
-			content="NDA-safe 4-year JusMundi summary: company history, team context, infrastructure scope, and senior architect achievements."
+			content="4-year JusMundi summary: company history, team context, infrastructure scope, and senior architect achievements."
 		/>
 		<meta property="og:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
 		<meta property="twitter:card" content="summary" />
@@ -30,7 +30,7 @@
 		<meta property="twitter:title" content="JusMundi — Senior Architect &amp; DevOps Impact" />
 		<meta
 			property="twitter:description"
-			content="NDA-safe 4-year JusMundi summary focused on architecture, delivery, and measurable outcomes."
+			content="4-year JusMundi summary focused on architecture, delivery, and measurable outcomes."
 		/>
 		<meta property="twitter:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
 		<link rel="canonical" href="https://dr-alban.com/cv/jusmundi/" />
@@ -78,7 +78,7 @@
 			<section class="hero-section jusmundi-hero-compact" aria-labelledby="hero-heading">
 				<div class="hero-content">
 					<h1 class="hero-title" id="hero-heading">JusMundi — Senior Architect &amp; DevOps Impact</h1>
-					<p class="hero-subtitle">Consolidated 4-year review (NDA-safe): history, team, infrastructure, achievements</p>
+					<p class="hero-subtitle">Consolidated 4-year review: history, team, infrastructure, achievements</p>
 				</div>
 			</section>
 
@@ -93,7 +93,7 @@
 					<p>
 						Across this period, the trajectory has been consistent: stronger product depth, increased operational
 						maturity, and a growing global footprint. This page intentionally focuses on public positioning and
-						execution outcomes, without disclosing confidential business or architecture information.
+						execution outcomes, while keeping the focus on business and delivery outcomes.
 					</p>
 				</div>
 			</section>
@@ -220,7 +220,7 @@
 					<a href="infrastructure-costs.html" class="service-card jusmundi-doc-card">
 						<div class="service-icon" aria-hidden="true"><i class="fas fa-server"></i></div>
 						<h3>Infrastructure overview</h3>
-						<p class="service-lead">NDA-safe architecture scope, reliability model, and governance approach.</p>
+						<p class="service-lead">Architecture scope, reliability model, and governance approach.</p>
 					</a>
 					<a href="4-years-review-aandrieu.html" class="service-card jusmundi-doc-card">
 						<div class="service-icon" aria-hidden="true"><i class="fas fa-user-tie"></i></div>
@@ -293,7 +293,7 @@
 				<a href="/cv" class="btn btn-sm btn-outline-secondary">Return to CV</a>
 				<a href="#top" class="btn btn-sm btn-outline-secondary ms-2" aria-label="Back to top of page">Back to top</a>
 			</p>
-			<p class="text-muted small mt-2">Consolidated and NDA-safe career summary.</p>
+			<p class="text-muted small mt-2">Consolidated career summary.</p>
 			<p class="footer-copyright"></p>
 		</footer>
 		<script src="../../site-widgets.js" defer data-print-pdf data-coffee-fab></script>

--- a/public/cv/jusmundi/index.html
+++ b/public/cv/jusmundi/index.html
@@ -285,8 +285,8 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing">Pricing</a>
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/pricing.html">Pricing</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/cv/jusmundi/index.html
+++ b/public/cv/jusmundi/index.html
@@ -1,0 +1,293 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>JusMundi — Senior Architect &amp; DevOps Impact | Alban Andrieu</title>
+		<meta
+			name="description"
+			content="NDA-safe 4-year JusMundi summary: company history, team context, infrastructure scope, and senior architect achievements."
+		/>
+		<meta
+			name="keywords"
+			content="Alban Andrieu, JusMundi, Senior Architect, DevOps, Platform Engineering, infrastructure, achievements"
+		/>
+		<meta name="author" content="Alban Andrieu" />
+		<meta name="robots" content="index, follow" />
+		<meta name="referrer" content="always" />
+		<meta name="color-scheme" content="light dark" />
+		<meta name="image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://dr-alban.com/cv/jusmundi/" />
+		<meta property="og:title" content="JusMundi — Senior Architect &amp; DevOps Impact | Alban Andrieu" />
+		<meta
+			property="og:description"
+			content="NDA-safe 4-year JusMundi summary: company history, team context, infrastructure scope, and senior architect achievements."
+		/>
+		<meta property="og:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
+		<meta property="twitter:card" content="summary" />
+		<meta property="twitter:url" content="https://dr-alban.com/cv/jusmundi/" />
+		<meta property="twitter:title" content="JusMundi — Senior Architect &amp; DevOps Impact" />
+		<meta
+			property="twitter:description"
+			content="NDA-safe 4-year JusMundi summary focused on architecture, delivery, and measurable outcomes."
+		/>
+		<meta property="twitter:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
+		<link rel="canonical" href="https://dr-alban.com/cv/jusmundi/" />
+		<link rel="icon" href="../../assets/nabla/nabla-4.svg" />
+		<link href="/assets/fontawesome/css/fontawesome.css" rel="stylesheet" />
+		<link href="/assets/fontawesome/css/brands.css" rel="stylesheet" />
+		<link href="/assets/fontawesome/css/solid.css" rel="stylesheet" />
+		<link rel="stylesheet" href="../../landing-sections.css" />
+		<link rel="stylesheet" href="../../wireframe.css" />
+		<link rel="stylesheet" href="../../theme.css" />
+		<link rel="stylesheet" href="../../style.css" />
+		<link rel="stylesheet" href="../../print.css" />
+		<link rel="stylesheet" href="../cv-theme.css" />
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.1/css/bootstrap.min.css"
+			integrity="sha512-siwe/oXMhSjGCwLn+scraPOWrJxHlUgMBMZXdPe2Tnk3I0x3ESCoLz7WZ5NTH6SZrywMY+PB1cjyqJ5jAluCOg=="
+			crossorigin="anonymous"
+			referrerpolicy="no-referrer"
+		/>
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.9.1/font/bootstrap-icons.min.css"
+			integrity="sha512-5PV92qsds/16vyYIJo3T/As4m2d8b6oWYfoqV+vtizRB6KhF1F9kYzWzQmsO6T3z3QG2Xdhrx7FQ+5R1LiQdUA=="
+			crossorigin="anonymous"
+			referrerpolicy="no-referrer"
+		/>
+		<link rel="stylesheet" href="../../site-content-page.css" />
+		<link rel="stylesheet" href="jusmundi.css" />
+		<script src="../../theme-toggle.js"></script>
+		<script src="../../site-google-translate.js" defer></script>
+		<script src="../../site-analytics.js"></script>
+	</head>
+	<body class="site-content-page jusmundi-page jusmundi-landing-page page-dark">
+		<a name="top"></a>
+		<a href="#main-content" class="skip-link">Skip to main content</a>
+
+		<nav class="page-nav container py-3 d-flex flex-wrap align-items-center gap-2" aria-label="Breadcrumb">
+			<a href="/cv" class="text-decoration-none" aria-label="Back to CV index">
+				<span aria-hidden="true">←</span> Back to CV
+			</a>
+		</nav>
+
+		<main id="main-content" role="main" class="container py-4 pb-5">
+			<section class="hero-section jusmundi-hero-compact" aria-labelledby="hero-heading">
+				<div class="hero-content">
+					<h1 class="hero-title" id="hero-heading">JusMundi — Senior Architect &amp; DevOps Impact</h1>
+					<p class="hero-subtitle">Consolidated 4-year review (NDA-safe): history, team, infrastructure, achievements</p>
+				</div>
+			</section>
+
+			<section class="proof-section jusmundi-landing-content" aria-labelledby="history-heading">
+				<h2 class="section-title" id="history-heading">1) JusMundi in context: mission and history</h2>
+				<div class="service-card jusmundi-service-card-wide">
+					<p>
+						JusMundi was launched in 2019 as a legal intelligence platform focused on international law and arbitration.
+						The company expanded from a specialized legal research product into a broader AI-enabled platform supporting
+						discovery, analysis, and drafting workflows for legal professionals.
+					</p>
+					<p>
+						Across this period, the trajectory has been consistent: stronger product depth, increased operational
+						maturity, and a growing global footprint. This page intentionally focuses on public positioning and
+						execution outcomes, without disclosing confidential business or architecture information.
+					</p>
+				</div>
+			</section>
+
+			<section class="services-section jusmundi-landing-content" aria-labelledby="team-heading">
+				<h2 class="section-title" id="team-heading">2) Team context as a DevOps architect</h2>
+				<p class="section-subtitle">Public team data, with size and percentages only</p>
+				<div class="service-card jusmundi-service-card-wide">
+					<div class="jusmundi-table-card">
+						<table class="kpi-table" role="table" aria-label="Public team composition">
+							<thead>
+								<tr>
+									<th scope="col">Team (public pages)</th>
+									<th scope="col">Approx. size</th>
+									<th scope="col">Share of featured teams</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Tech</td>
+									<td>~25</td>
+									<td>~38%</td>
+								</tr>
+								<tr>
+									<td>Global Sales</td>
+									<td>~21</td>
+									<td>~32%</td>
+								</tr>
+								<tr>
+									<td>Product</td>
+									<td>~10</td>
+									<td>~15%</td>
+								</tr>
+								<tr>
+									<td>Customer Success / Care</td>
+									<td>~10</td>
+									<td>~15%</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+					<p>
+						My DevOps and platform work sat at the intersection of these groups: enabling engineering throughput,
+						protecting reliability for customer-facing teams, and keeping platform foundations aligned with product
+						evolution.
+					</p>
+				</div>
+			</section>
+
+			<section class="proof-section jusmundi-landing-content" aria-labelledby="infra-heading">
+				<h2 class="section-title" id="infra-heading">3) Global infrastructure scope (high-level)</h2>
+				<div class="services-grid">
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-globe"></i></div>
+						<h3>Multi-environment platform operations</h3>
+						<p class="service-lead">
+							Production and non-production environments operated with consistent controls for reliability, security, and
+							recoverability.
+						</p>
+					</div>
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-shield-halved"></i></div>
+						<h3>Security by default</h3>
+						<p class="service-lead">
+							Identity, access management, network protection, and vulnerability remediation integrated into day-to-day
+							delivery.
+						</p>
+					</div>
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-chart-line"></i></div>
+						<h3>Observability and reliability engineering</h3>
+						<p class="service-lead">
+							Metrics, logs, traces, and incident runbooks used to cut time-to-detect and time-to-recover.
+						</p>
+					</div>
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-code-branch"></i></div>
+						<h3>Automation and delivery excellence</h3>
+						<p class="service-lead">
+							Infrastructure as code and CI/CD standards reduced manual drift and improved release confidence.
+						</p>
+					</div>
+				</div>
+			</section>
+
+			<section class="services-section jusmundi-landing-content" aria-labelledby="projects-heading">
+				<h2 class="section-title" id="projects-heading">4) Projects and tasks delivered over 4 years</h2>
+				<div class="service-card jusmundi-service-card-wide">
+					<ul class="summary-list">
+						<li>Architecture and delivery practices that reduced manual configuration errors by ~90%.</li>
+						<li>Reliability improvements that reduced alert noise by ~60% and improved operational focus.</li>
+						<li>Security hardening programs that shortened critical remediation lead time by more than 50%.</li>
+						<li>Incident-response maturity that reduced mean recovery time by around 50% on priority incidents.</li>
+						<li>CI/CD and platform standardization that improved delivery predictability and release quality.</li>
+					</ul>
+					<p>
+						The cumulative result is a senior architect profile combining platform depth, cross-team leadership, and
+						measurable execution under operational constraints.
+					</p>
+				</div>
+			</section>
+
+			<section class="proof-section jusmundi-landing-content" aria-labelledby="documents-heading">
+				<h2 class="section-title" id="documents-heading">Detailed pages</h2>
+				<div class="services-grid">
+					<a href="4-years-review-jusmundi.html" class="service-card jusmundi-doc-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-building"></i></div>
+						<h3>Company history and positioning</h3>
+						<p class="service-lead">Public overview of mission, product evolution, and strategic direction.</p>
+					</a>
+					<a href="structure.html" class="service-card jusmundi-doc-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-users"></i></div>
+						<h3>Team composition (public figures)</h3>
+						<p class="service-lead">Team size and percentage distribution relevant to DevOps collaboration.</p>
+					</a>
+					<a href="infrastructure-costs.html" class="service-card jusmundi-doc-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-server"></i></div>
+						<h3>Infrastructure overview</h3>
+						<p class="service-lead">NDA-safe architecture scope, reliability model, and governance approach.</p>
+					</a>
+					<a href="4-years-review-aandrieu.html" class="service-card jusmundi-doc-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-user-tie"></i></div>
+						<h3>Senior architect achievements</h3>
+						<p class="service-lead">Four-year project portfolio and measurable outcomes.</p>
+					</a>
+					<a href="yearly-review-2025-aandrieu.html" class="service-card jusmundi-doc-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-calendar-check"></i></div>
+						<h3>Most recent yearly focus</h3>
+						<p class="service-lead">Latest execution highlights and leadership priorities.</p>
+					</a>
+				</div>
+			</section>
+		</main>
+
+		<footer class="footer" role="contentinfo">
+			<div class="social-links">
+				<a
+					href="https://www.linkedin.com/in/nabla"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="LinkedIn"
+				>
+					<i class="fab fa-linkedin-in"></i>
+				</a>
+				<a
+					href="https://calendly.com/alban-andrieu"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="Calendly"
+				>
+					<i class="fa fa-calendar-plus"></i>
+				</a>
+				<a
+					href="https://github.com/AlbanAndrieu"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="GitHub"
+				>
+					<i class="fab fa-github"></i>
+				</a>
+				<a
+					href="https://hub.docker.com/u/nabla"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="Docker Hub"
+				>
+					<i class="fab fa-docker"></i>
+				</a>
+				<a
+					href="https://stackexchange.com/users/4652074/albanandrieu"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="Stack Exchange"
+				>
+					<i class="fab fa-stack-exchange"></i>
+				</a>
+			</div>
+			<div class="footer-links">
+				<a href="/pricing">Pricing</a>
+				<a href="/policy/legal">Legal notices</a>
+				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
+			</div>
+			<p class="text-md-center mt-3">
+				<a href="/cv" class="btn btn-sm btn-outline-secondary">Return to CV</a>
+				<a href="#top" class="btn btn-sm btn-outline-secondary ms-2" aria-label="Back to top of page">Back to top</a>
+			</p>
+			<p class="text-muted small mt-2">Consolidated and NDA-safe career summary.</p>
+			<p class="footer-copyright"></p>
+		</footer>
+		<script src="../../site-widgets.js" defer data-print-pdf data-coffee-fab></script>
+	</body>
+</html>

--- a/public/cv/jusmundi/index.html
+++ b/public/cv/jusmundi/index.html
@@ -6,7 +6,7 @@
 		<title>JusMundi — Senior Architect &amp; DevOps Impact | Alban Andrieu</title>
 		<meta
 			name="description"
-			content="4-year JusMundi summary: company history, team context, infrastructure scope, and senior architect achievements."
+			content="NDA-safe 4-year JusMundi summary: company history, team context, infrastructure scope, and senior architect achievements."
 		/>
 		<meta
 			name="keywords"
@@ -22,7 +22,7 @@
 		<meta property="og:title" content="JusMundi — Senior Architect &amp; DevOps Impact | Alban Andrieu" />
 		<meta
 			property="og:description"
-			content="4-year JusMundi summary: company history, team context, infrastructure scope, and senior architect achievements."
+			content="NDA-safe 4-year JusMundi summary: company history, team context, infrastructure scope, and senior architect achievements."
 		/>
 		<meta property="og:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
 		<meta property="twitter:card" content="summary" />
@@ -30,7 +30,7 @@
 		<meta property="twitter:title" content="JusMundi — Senior Architect &amp; DevOps Impact" />
 		<meta
 			property="twitter:description"
-			content="4-year JusMundi summary focused on architecture, delivery, and measurable outcomes."
+			content="NDA-safe 4-year JusMundi summary focused on architecture, delivery, and measurable outcomes."
 		/>
 		<meta property="twitter:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
 		<link rel="canonical" href="https://dr-alban.com/cv/jusmundi/" />
@@ -78,7 +78,7 @@
 			<section class="hero-section jusmundi-hero-compact" aria-labelledby="hero-heading">
 				<div class="hero-content">
 					<h1 class="hero-title" id="hero-heading">JusMundi — Senior Architect &amp; DevOps Impact</h1>
-					<p class="hero-subtitle">Consolidated 4-year review: history, team, infrastructure, achievements</p>
+					<p class="hero-subtitle">Consolidated 4-year review (NDA-safe): history, team, infrastructure, achievements</p>
 				</div>
 			</section>
 
@@ -93,96 +93,88 @@
 					<p>
 						Across this period, the trajectory has been consistent: stronger product depth, increased operational
 						maturity, and a growing global footprint. This page intentionally focuses on public positioning and
-						execution outcomes, while keeping the focus on business and delivery outcomes.
+						execution outcomes, without disclosing confidential business or architecture information.
 					</p>
 				</div>
 			</section>
 
 			<section class="services-section jusmundi-landing-content" aria-labelledby="team-heading">
-				<h2 class="section-title" id="team-heading">2) Team context and operating model (aggregated)</h2>
-				<p class="section-subtitle">Structure + infrastructure context consolidated on this page</p>
+				<h2 class="section-title" id="team-heading">2) Team context as a DevOps architect</h2>
+				<p class="section-subtitle">Public team data, with size and percentages only</p>
 				<div class="service-card jusmundi-service-card-wide">
 					<div class="jusmundi-table-card">
-						<table class="kpi-table" role="table" aria-label="Company and team context">
+						<table class="kpi-table" role="table" aria-label="Public team composition">
 							<thead>
 								<tr>
-									<th scope="col">Scope</th>
+									<th scope="col">Team (public pages)</th>
 									<th scope="col">Approx. size</th>
-									<th scope="col">Notes</th>
+									<th scope="col">Share of featured teams</th>
 								</tr>
 							</thead>
 							<tbody>
 								<tr>
-									<td>Total company</td>
-									<td>~100 to ~115 people</td>
-									<td>Cross-functional global organization</td>
+									<td>Tech</td>
+									<td>~25</td>
+									<td>~38%</td>
 								</tr>
 								<tr>
-									<td>Tech organization (EPD)</td>
-									<td>~26 engineers</td>
-									<td>Platform, Search, Core AI, Growth, Legal Data Collection</td>
+									<td>Global Sales</td>
+									<td>~21</td>
+									<td>~32%</td>
 								</tr>
 								<tr>
-									<td>Infrastructure and Security &amp; IT team</td>
-									<td>~2 people on average</td>
-									<td>Supporting the whole company, including all ~26 tech profiles</td>
+									<td>Product</td>
+									<td>~10</td>
+									<td>~15%</td>
+								</tr>
+								<tr>
+									<td>Customer Success / Care</td>
+									<td>~10</td>
+									<td>~15%</td>
 								</tr>
 							</tbody>
 						</table>
 					</div>
-					<p class="mt-3 mb-0">
-						<strong>Highlight:</strong> a lean infrastructure team of 2 supported a full-scale platform operation for the
-						entire company, including ~26 tech members, with a high degree of automation and reliability ownership.
+					<p>
+						My DevOps and platform work sat at the intersection of these groups: enabling engineering throughput,
+						protecting reliability for customer-facing teams, and keeping platform foundations aligned with product
+						evolution.
 					</p>
 				</div>
 			</section>
 
 			<section class="proof-section jusmundi-landing-content" aria-labelledby="infra-heading">
-				<h2 class="section-title" id="infra-heading">3) Global infrastructure architecture and footprint</h2>
-				<div class="service-card jusmundi-service-card-wide">
-					<p>
-						The platform evolved from OVH/Nomad foundations toward multi-site Kubernetes-oriented operations across
-						<strong>EU and US</strong>, with a strong focus on AI workloads and secure, observable service delivery.
-					</p>
-					<div class="jusmundi-table-card">
-						<table class="kpi-table" role="table" aria-label="Infrastructure providers and focus areas">
-							<thead>
-								<tr>
-									<th scope="col">Provider / stack</th>
-									<th scope="col">Primary role</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>OVH</td>
-									<td>Core compute, storage, and databases</td>
-								</tr>
-								<tr>
-									<td>AWS</td>
-									<td>US expansion and Kubernetes-oriented cloud footprint</td>
-								</tr>
-								<tr>
-									<td>Azure OpenAI and OpenAI</td>
-									<td>AI/LLM capabilities and document intelligence acceleration</td>
-								</tr>
-								<tr>
-									<td>Cloudflare</td>
-									<td>WAF, anti-scraping, traffic protection, edge controls</td>
-								</tr>
-								<tr>
-									<td>Datadog + observability stack</td>
-									<td>Monitoring, APM, tracing, and operational visibility</td>
-								</tr>
-							</tbody>
-						</table>
+				<h2 class="section-title" id="infra-heading">3) Global infrastructure scope (high-level)</h2>
+				<div class="services-grid">
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-globe"></i></div>
+						<h3>Multi-environment platform operations</h3>
+						<p class="service-lead">
+							Production and non-production environments operated with consistent controls for reliability, security, and
+							recoverability.
+						</p>
 					</div>
-					<div class="badge-row mt-3">
-						<span class="badge">Nomad to Kubernetes migration path</span>
-						<span class="badge">EU + US deployments</span>
-						<span class="badge">AI-focused infrastructure</span>
-						<span class="badge">Elasticsearch and GPU workloads</span>
-						<span class="badge">Keycloak identity platform</span>
-						<span class="badge">Terraform and Ansible automation</span>
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-shield-halved"></i></div>
+						<h3>Security by default</h3>
+						<p class="service-lead">
+							Identity, access management, network protection, and vulnerability remediation integrated into day-to-day
+							delivery.
+						</p>
+					</div>
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-chart-line"></i></div>
+						<h3>Observability and reliability engineering</h3>
+						<p class="service-lead">
+							Metrics, logs, traces, and incident runbooks used to cut time-to-detect and time-to-recover.
+						</p>
+					</div>
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-code-branch"></i></div>
+						<h3>Automation and delivery excellence</h3>
+						<p class="service-lead">
+							Infrastructure as code and CI/CD standards reduced manual drift and improved release confidence.
+						</p>
 					</div>
 				</div>
 			</section>
@@ -220,7 +212,7 @@
 					<a href="infrastructure-costs.html" class="service-card jusmundi-doc-card">
 						<div class="service-icon" aria-hidden="true"><i class="fas fa-server"></i></div>
 						<h3>Infrastructure overview</h3>
-						<p class="service-lead">Architecture scope, reliability model, and governance approach.</p>
+						<p class="service-lead">NDA-safe architecture scope, reliability model, and governance approach.</p>
 					</a>
 					<a href="4-years-review-aandrieu.html" class="service-card jusmundi-doc-card">
 						<div class="service-icon" aria-hidden="true"><i class="fas fa-user-tie"></i></div>
@@ -285,14 +277,15 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/policy/legal.html">Legal notices</a>
+				<a href="/pricing">Pricing</a>
+				<a href="/policy/legal">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">
 				<a href="/cv" class="btn btn-sm btn-outline-secondary">Return to CV</a>
 				<a href="#top" class="btn btn-sm btn-outline-secondary ms-2" aria-label="Back to top of page">Back to top</a>
 			</p>
-			<p class="text-muted small mt-2">Consolidated career summary.</p>
+			<p class="text-muted small mt-2">Consolidated and NDA-safe career summary.</p>
 			<p class="footer-copyright"></p>
 		</footer>
 		<script src="../../site-widgets.js" defer data-print-pdf data-coffee-fab></script>

--- a/public/cv/jusmundi/index.html
+++ b/public/cv/jusmundi/index.html
@@ -99,82 +99,90 @@
 			</section>
 
 			<section class="services-section jusmundi-landing-content" aria-labelledby="team-heading">
-				<h2 class="section-title" id="team-heading">2) Team context as a DevOps architect</h2>
-				<p class="section-subtitle">Public team data, with size and percentages only</p>
+				<h2 class="section-title" id="team-heading">2) Team context and operating model (aggregated)</h2>
+				<p class="section-subtitle">Structure + infrastructure context consolidated on this page</p>
 				<div class="service-card jusmundi-service-card-wide">
 					<div class="jusmundi-table-card">
-						<table class="kpi-table" role="table" aria-label="Public team composition">
+						<table class="kpi-table" role="table" aria-label="Company and team context">
 							<thead>
 								<tr>
-									<th scope="col">Team (public pages)</th>
+									<th scope="col">Scope</th>
 									<th scope="col">Approx. size</th>
-									<th scope="col">Share of featured teams</th>
+									<th scope="col">Notes</th>
 								</tr>
 							</thead>
 							<tbody>
 								<tr>
-									<td>Tech</td>
-									<td>~25</td>
-									<td>~38%</td>
+									<td>Total company</td>
+									<td>~100 to ~115 people</td>
+									<td>Cross-functional global organization</td>
 								</tr>
 								<tr>
-									<td>Global Sales</td>
-									<td>~21</td>
-									<td>~32%</td>
+									<td>Tech organization (EPD)</td>
+									<td>~26 engineers</td>
+									<td>Platform, Search, Core AI, Growth, Legal Data Collection</td>
 								</tr>
 								<tr>
-									<td>Product</td>
-									<td>~10</td>
-									<td>~15%</td>
-								</tr>
-								<tr>
-									<td>Customer Success / Care</td>
-									<td>~10</td>
-									<td>~15%</td>
+									<td>Infrastructure and Security &amp; IT team</td>
+									<td>~2 people on average</td>
+									<td>Supporting the whole company, including all ~26 tech profiles</td>
 								</tr>
 							</tbody>
 						</table>
 					</div>
-					<p>
-						My DevOps and platform work sat at the intersection of these groups: enabling engineering throughput,
-						protecting reliability for customer-facing teams, and keeping platform foundations aligned with product
-						evolution.
+					<p class="mt-3 mb-0">
+						<strong>Highlight:</strong> a lean infrastructure team of 2 supported a full-scale platform operation for the
+						entire company, including ~26 tech members, with a high degree of automation and reliability ownership.
 					</p>
 				</div>
 			</section>
 
 			<section class="proof-section jusmundi-landing-content" aria-labelledby="infra-heading">
-				<h2 class="section-title" id="infra-heading">3) Global infrastructure scope (high-level)</h2>
-				<div class="services-grid">
-					<div class="service-card">
-						<div class="service-icon" aria-hidden="true"><i class="fas fa-globe"></i></div>
-						<h3>Multi-environment platform operations</h3>
-						<p class="service-lead">
-							Production and non-production environments operated with consistent controls for reliability, security, and
-							recoverability.
-						</p>
+				<h2 class="section-title" id="infra-heading">3) Global infrastructure architecture and footprint</h2>
+				<div class="service-card jusmundi-service-card-wide">
+					<p>
+						The platform evolved from OVH/Nomad foundations toward multi-site Kubernetes-oriented operations across
+						<strong>EU and US</strong>, with a strong focus on AI workloads and secure, observable service delivery.
+					</p>
+					<div class="jusmundi-table-card">
+						<table class="kpi-table" role="table" aria-label="Infrastructure providers and focus areas">
+							<thead>
+								<tr>
+									<th scope="col">Provider / stack</th>
+									<th scope="col">Primary role</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>OVH</td>
+									<td>Core compute, storage, and databases</td>
+								</tr>
+								<tr>
+									<td>AWS</td>
+									<td>US expansion and Kubernetes-oriented cloud footprint</td>
+								</tr>
+								<tr>
+									<td>Azure OpenAI and OpenAI</td>
+									<td>AI/LLM capabilities and document intelligence acceleration</td>
+								</tr>
+								<tr>
+									<td>Cloudflare</td>
+									<td>WAF, anti-scraping, traffic protection, edge controls</td>
+								</tr>
+								<tr>
+									<td>Datadog + observability stack</td>
+									<td>Monitoring, APM, tracing, and operational visibility</td>
+								</tr>
+							</tbody>
+						</table>
 					</div>
-					<div class="service-card">
-						<div class="service-icon" aria-hidden="true"><i class="fas fa-shield-halved"></i></div>
-						<h3>Security by default</h3>
-						<p class="service-lead">
-							Identity, access management, network protection, and vulnerability remediation integrated into day-to-day
-							delivery.
-						</p>
-					</div>
-					<div class="service-card">
-						<div class="service-icon" aria-hidden="true"><i class="fas fa-chart-line"></i></div>
-						<h3>Observability and reliability engineering</h3>
-						<p class="service-lead">
-							Metrics, logs, traces, and incident runbooks used to cut time-to-detect and time-to-recover.
-						</p>
-					</div>
-					<div class="service-card">
-						<div class="service-icon" aria-hidden="true"><i class="fas fa-code-branch"></i></div>
-						<h3>Automation and delivery excellence</h3>
-						<p class="service-lead">
-							Infrastructure as code and CI/CD standards reduced manual drift and improved release confidence.
-						</p>
+					<div class="badge-row mt-3">
+						<span class="badge">Nomad to Kubernetes migration path</span>
+						<span class="badge">EU + US deployments</span>
+						<span class="badge">AI-focused infrastructure</span>
+						<span class="badge">Elasticsearch and GPU workloads</span>
+						<span class="badge">Keycloak identity platform</span>
+						<span class="badge">Terraform and Ansible automation</span>
 					</div>
 				</div>
 			</section>

--- a/public/cv/jusmundi/index.html
+++ b/public/cv/jusmundi/index.html
@@ -6,7 +6,7 @@
 		<title>JusMundi — Senior Architect &amp; DevOps Impact | Alban Andrieu</title>
 		<meta
 			name="description"
-			content="NDA-safe 4-year JusMundi summary: company history, team context, infrastructure scope, and senior architect achievements."
+			content="4-year JusMundi summary: company history, team context, infrastructure scope, and senior architect achievements."
 		/>
 		<meta
 			name="keywords"
@@ -22,7 +22,7 @@
 		<meta property="og:title" content="JusMundi — Senior Architect &amp; DevOps Impact | Alban Andrieu" />
 		<meta
 			property="og:description"
-			content="NDA-safe 4-year JusMundi summary: company history, team context, infrastructure scope, and senior architect achievements."
+			content="4-year JusMundi summary: company history, team context, infrastructure scope, and senior architect achievements."
 		/>
 		<meta property="og:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
 		<meta property="twitter:card" content="summary" />
@@ -30,7 +30,7 @@
 		<meta property="twitter:title" content="JusMundi — Senior Architect &amp; DevOps Impact" />
 		<meta
 			property="twitter:description"
-			content="NDA-safe 4-year JusMundi summary focused on architecture, delivery, and measurable outcomes."
+			content="4-year JusMundi summary focused on architecture, delivery, and measurable outcomes."
 		/>
 		<meta property="twitter:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
 		<link rel="canonical" href="https://dr-alban.com/cv/jusmundi/" />
@@ -78,7 +78,7 @@
 			<section class="hero-section jusmundi-hero-compact" aria-labelledby="hero-heading">
 				<div class="hero-content">
 					<h1 class="hero-title" id="hero-heading">JusMundi — Senior Architect &amp; DevOps Impact</h1>
-					<p class="hero-subtitle">Consolidated 4-year review (NDA-safe): history, team, infrastructure, achievements</p>
+					<p class="hero-subtitle">Consolidated 4-year review: history, team, infrastructure, and achievements</p>
 				</div>
 			</section>
 
@@ -92,8 +92,8 @@
 					</p>
 					<p>
 						Across this period, the trajectory has been consistent: stronger product depth, increased operational
-						maturity, and a growing global footprint. This page intentionally focuses on public positioning and
-						execution outcomes, without disclosing confidential business or architecture information.
+						maturity, and a growing global footprint. This page focuses on company positioning and execution
+						outcomes to present a clear senior architect impact narrative.
 					</p>
 				</div>
 			</section>
@@ -247,15 +247,13 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing">Pricing</a>
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">
 				<a href="/cv" class="btn btn-sm btn-outline-secondary">Return to CV</a>
-				<a href="#top" class="btn btn-sm btn-outline-secondary ms-2" aria-label="Back to top of page">Back to top</a>
 			</p>
-			<p class="text-muted small mt-2">Consolidated and NDA-safe career summary.</p>
+			<p class="text-muted small mt-2">Consolidated career summary.</p>
 			<p class="footer-copyright"></p>
 		</footer>
 		<script src="../../site-widgets.js" defer data-print-pdf data-coffee-fab></script>

--- a/public/cv/jusmundi/infrastructure-costs.html
+++ b/public/cv/jusmundi/infrastructure-costs.html
@@ -217,7 +217,6 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing.html">Pricing</a>
 				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>

--- a/public/cv/jusmundi/infrastructure-costs.html
+++ b/public/cv/jusmundi/infrastructure-costs.html
@@ -66,11 +66,11 @@
 		<a href="#main-content" class="skip-link">Skip to main content</a>
 
 		<nav class="page-nav container py-3 d-flex flex-wrap align-items-center gap-2" aria-label="Breadcrumb">
-			<a href="/cv/jusmundi" class="text-decoration-none" aria-label="Back to Jusmundi index">
-				<span aria-hidden="true">←</span> Jusmundi
+			<a href="/cv/jusmundi" class="text-decoration-none" aria-label="Back to JusMundi index">
+				<span aria-hidden="true">←</span> JusMundi
 			</a>
 			<span class="opacity-75" aria-hidden="true">·</span>
-			<a href="/cv" class="text-decoration-none" aria-label="Back to CV index">CV index</a>
+			<a href="/cv" class="text-decoration-none" aria-label="Back to CV index">Return to CV</a>
 		</nav>
 
 		<main id="main-content" role="main" class="container py-4 pb-5">
@@ -221,9 +221,8 @@
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">
-				<a href="/cv/jusmundi" class="btn btn-sm btn-outline-secondary">Jusmundi index</a>
-				<a href="/cv" class="btn btn-sm btn-outline-secondary ms-2">CV index</a>
-				<a href="#top" class="btn btn-sm btn-outline-secondary ms-2" aria-label="Back to top of page">Back to top</a>
+				<a href="/cv/jusmundi" class="btn btn-sm btn-outline-secondary">Return to JusMundi index</a>
+				<a href="/cv" class="btn btn-sm btn-outline-secondary ms-2">Return to CV</a>
 			</p>
 			<p class="text-muted small mt-2">Infrastructure scope and outcomes.</p>
 			<p class="footer-copyright"></p>

--- a/public/cv/jusmundi/infrastructure-costs.html
+++ b/public/cv/jusmundi/infrastructure-costs.html
@@ -6,7 +6,7 @@
 		<title>JusMundi — Infrastructure Overview | Alban Andrieu</title>
 		<meta
 			name="description"
-			content="NDA-safe infrastructure overview: architecture scope, operations model, and platform outcomes across 4 years."
+			content="Infrastructure overview: architecture scope, operations model, and platform outcomes across 4 years."
 		/>
 		<meta
 			name="keywords"
@@ -22,13 +22,13 @@
 		<meta property="og:title" content="JusMundi — Infrastructure Overview | Alban Andrieu" />
 		<meta
 			property="og:description"
-			content="NDA-safe infrastructure overview: architecture scope, operations model, and platform outcomes."
+			content="Infrastructure overview: architecture scope, operations model, and platform outcomes."
 		/>
 		<meta property="og:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
 		<meta property="twitter:card" content="summary" />
 		<meta property="twitter:url" content="https://dr-alban.com/cv/jusmundi/infrastructure-costs.html" />
 		<meta property="twitter:title" content="JusMundi — Infrastructure Overview" />
-		<meta property="twitter:description" content="NDA-safe architecture and platform operations overview." />
+		<meta property="twitter:description" content="Architecture and platform operations overview." />
 		<meta property="twitter:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
 		<link rel="canonical" href="https://dr-alban.com/cv/jusmundi/infrastructure-costs.html" />
 		<link rel="icon" href="../../assets/nabla/nabla-4.svg" />
@@ -77,7 +77,7 @@
 			<section class="hero-section jusmundi-hero-compact" aria-labelledby="hero-heading">
 				<div class="hero-content">
 					<h1 class="hero-title" id="hero-heading">Infrastructure Overview</h1>
-					<p class="hero-subtitle">NDA-safe platform architecture and operations across the last 4 years</p>
+					<p class="hero-subtitle">Platform architecture and operations across the last 4 years</p>
 				</div>
 			</section>
 
@@ -121,7 +121,7 @@
 			</section>
 
 			<section class="proof-section jusmundi-landing-content" aria-labelledby="outcomes-heading">
-				<h2 class="section-title" id="outcomes-heading">Measured outcomes (sanitized)</h2>
+				<h2 class="section-title" id="outcomes-heading">Measured outcomes</h2>
 				<div class="service-card jusmundi-service-card-wide">
 					<div class="jusmundi-table-card">
 						<table class="kpi-table" role="table" aria-label="Infrastructure outcomes">
@@ -162,7 +162,7 @@
 						incremental migration planning, deployment guardrails, and shared operational ownership with product teams.
 					</p>
 					<p>
-						This model enabled growth while preserving confidentiality, compliance posture, and production stability.
+						This model enabled growth while preserving compliance posture and production stability.
 					</p>
 				</div>
 			</section>
@@ -226,7 +226,7 @@
 				<a href="/cv" class="btn btn-sm btn-outline-secondary ms-2">CV index</a>
 				<a href="#top" class="btn btn-sm btn-outline-secondary ms-2" aria-label="Back to top of page">Back to top</a>
 			</p>
-			<p class="text-muted small mt-2">NDA-safe infrastructure scope and outcomes.</p>
+			<p class="text-muted small mt-2">Infrastructure scope and outcomes.</p>
 			<p class="footer-copyright"></p>
 		</footer>
 		<script src="../../site-widgets.js" defer data-print-pdf data-coffee-fab></script>

--- a/public/cv/jusmundi/infrastructure-costs.html
+++ b/public/cv/jusmundi/infrastructure-costs.html
@@ -217,8 +217,8 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing">Pricing</a>
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/pricing.html">Pricing</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/cv/jusmundi/infrastructure-costs.html
+++ b/public/cv/jusmundi/infrastructure-costs.html
@@ -1,0 +1,234 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>JusMundi — Infrastructure Overview | Alban Andrieu</title>
+		<meta
+			name="description"
+			content="NDA-safe infrastructure overview: architecture scope, operations model, and platform outcomes across 4 years."
+		/>
+		<meta
+			name="keywords"
+			content="Alban Andrieu, JusMundi, infrastructure, DevOps, platform engineering, reliability"
+		/>
+		<meta name="author" content="Alban Andrieu" />
+		<meta name="robots" content="noindex, nofollow" />
+		<meta name="referrer" content="always" />
+		<meta name="color-scheme" content="light dark" />
+		<meta name="image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://dr-alban.com/cv/jusmundi/infrastructure-costs.html" />
+		<meta property="og:title" content="JusMundi — Infrastructure Overview | Alban Andrieu" />
+		<meta
+			property="og:description"
+			content="NDA-safe infrastructure overview: architecture scope, operations model, and platform outcomes."
+		/>
+		<meta property="og:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
+		<meta property="twitter:card" content="summary" />
+		<meta property="twitter:url" content="https://dr-alban.com/cv/jusmundi/infrastructure-costs.html" />
+		<meta property="twitter:title" content="JusMundi — Infrastructure Overview" />
+		<meta property="twitter:description" content="NDA-safe architecture and platform operations overview." />
+		<meta property="twitter:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
+		<link rel="canonical" href="https://dr-alban.com/cv/jusmundi/infrastructure-costs.html" />
+		<link rel="icon" href="../../assets/nabla/nabla-4.svg" />
+		<link href="/assets/fontawesome/css/fontawesome.css" rel="stylesheet" />
+		<link href="/assets/fontawesome/css/brands.css" rel="stylesheet" />
+		<link href="/assets/fontawesome/css/solid.css" rel="stylesheet" />
+		<link rel="stylesheet" href="../../landing-sections.css" />
+		<link rel="stylesheet" href="../../wireframe.css" />
+		<link rel="stylesheet" href="../../theme.css" />
+		<link rel="stylesheet" href="../../style.css" />
+		<link rel="stylesheet" href="../../print.css" />
+		<link rel="stylesheet" href="../cv-theme.css" />
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.1/css/bootstrap.min.css"
+			integrity="sha512-siwe/oXMhSjGCwLn+scraPOWrJxHlUgMBMZXdPe2Tnk3I0x3ESCoLz7WZ5NTH6SZrywMY+PB1cjyqJ5jAluCOg=="
+			crossorigin="anonymous"
+			referrerpolicy="no-referrer"
+		/>
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.9.1/font/bootstrap-icons.min.css"
+			integrity="sha512-5PV92qsds/16vyYIJo3T/As4m2d8b6oWYfoqV+vtizRB6KhF1F9kYzWzQmsO6T3z3QG2Xdhrx7FQ+5R1LiQdUA=="
+			crossorigin="anonymous"
+			referrerpolicy="no-referrer"
+		/>
+		<link rel="stylesheet" href="../../site-content-page.css" />
+		<link rel="stylesheet" href="jusmundi.css" />
+		<script src="../../theme-toggle.js"></script>
+		<script src="../../site-google-translate.js" defer></script>
+		<script src="../../site-analytics.js"></script>
+	</head>
+	<body class="site-content-page jusmundi-page jusmundi-landing-page page-dark">
+		<a name="top"></a>
+		<a href="#main-content" class="skip-link">Skip to main content</a>
+
+		<nav class="page-nav container py-3 d-flex flex-wrap align-items-center gap-2" aria-label="Breadcrumb">
+			<a href="/cv/jusmundi" class="text-decoration-none" aria-label="Back to Jusmundi index">
+				<span aria-hidden="true">←</span> Jusmundi
+			</a>
+			<span class="opacity-75" aria-hidden="true">·</span>
+			<a href="/cv" class="text-decoration-none" aria-label="Back to CV index">CV index</a>
+		</nav>
+
+		<main id="main-content" role="main" class="container py-4 pb-5">
+			<section class="hero-section jusmundi-hero-compact" aria-labelledby="hero-heading">
+				<div class="hero-content">
+					<h1 class="hero-title" id="hero-heading">Infrastructure Overview</h1>
+					<p class="hero-subtitle">NDA-safe platform architecture and operations across the last 4 years</p>
+				</div>
+			</section>
+
+			<section class="proof-section jusmundi-landing-content" aria-labelledby="scope-heading">
+				<h2 class="section-title" id="scope-heading">Global platform scope</h2>
+				<div class="service-card jusmundi-service-card-wide">
+					<ul class="service-bullets">
+						<li>Managed multi-environment operations across production, pre-production, and engineering platforms.</li>
+						<li>Supported regional expansion requirements with resilient network and deployment foundations.</li>
+						<li>
+							Implemented platform standards for uptime, observability, security controls, and incident management.
+						</li>
+					</ul>
+				</div>
+			</section>
+
+			<section class="services-section jusmundi-landing-content" aria-labelledby="capabilities-heading">
+				<h2 class="section-title" id="capabilities-heading">Architecture and operations capabilities</h2>
+				<div class="services-grid">
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-network-wired"></i></div>
+						<h3>Platform architecture</h3>
+						<p class="service-lead">Service orchestration, secure networking, and environment isolation.</p>
+					</div>
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-user-shield"></i></div>
+						<h3>Identity and access</h3>
+						<p class="service-lead">Centralized authentication controls and hardened access workflows.</p>
+					</div>
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-heartbeat"></i></div>
+						<h3>Reliability engineering</h3>
+						<p class="service-lead">Runbooks, alert quality improvements, and faster incident resolution.</p>
+					</div>
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-gears"></i></div>
+						<h3>Automation</h3>
+						<p class="service-lead">Infrastructure as code and CI/CD standardization to reduce drift and risk.</p>
+					</div>
+				</div>
+			</section>
+
+			<section class="proof-section jusmundi-landing-content" aria-labelledby="outcomes-heading">
+				<h2 class="section-title" id="outcomes-heading">Measured outcomes (sanitized)</h2>
+				<div class="service-card jusmundi-service-card-wide">
+					<div class="jusmundi-table-card">
+						<table class="kpi-table" role="table" aria-label="Infrastructure outcomes">
+							<thead>
+								<tr>
+									<th scope="col">Outcome area</th>
+									<th scope="col">Result</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Operational quality</td>
+									<td>~60% alert noise reduction and clearer on-call prioritization</td>
+								</tr>
+								<tr>
+									<td>Recovery speed</td>
+									<td>~50% improvement in mean recovery time on high-priority incidents</td>
+								</tr>
+								<tr>
+									<td>Change reliability</td>
+									<td>~90% reduction in manual configuration error rates with automation</td>
+								</tr>
+								<tr>
+									<td>Security responsiveness</td>
+									<td>Critical remediation lead time reduced by more than 50%</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</section>
+
+			<section class="services-section jusmundi-landing-content" aria-labelledby="governance-heading">
+				<h2 class="section-title" id="governance-heading">Governance and delivery model</h2>
+				<div class="service-card jusmundi-service-card-wide">
+					<p>
+						The infrastructure program was run as an architecture function with strong DevOps execution: design reviews,
+						incremental migration planning, deployment guardrails, and shared operational ownership with product teams.
+					</p>
+					<p>
+						This model enabled growth while preserving confidentiality, compliance posture, and production stability.
+					</p>
+				</div>
+			</section>
+		</main>
+
+		<footer class="footer" role="contentinfo">
+			<div class="social-links">
+				<a
+					href="https://www.linkedin.com/in/nabla"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="LinkedIn"
+				>
+					<i class="fab fa-linkedin-in"></i>
+				</a>
+				<a
+					href="https://calendly.com/alban-andrieu"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="Calendly"
+				>
+					<i class="fa fa-calendar-plus"></i>
+				</a>
+				<a
+					href="https://github.com/AlbanAndrieu"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="GitHub"
+				>
+					<i class="fab fa-github"></i>
+				</a>
+				<a
+					href="https://hub.docker.com/u/nabla"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="Docker Hub"
+				>
+					<i class="fab fa-docker"></i>
+				</a>
+				<a
+					href="https://stackexchange.com/users/4652074/albanandrieu"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="Stack Exchange"
+				>
+					<i class="fab fa-stack-exchange"></i>
+				</a>
+			</div>
+			<div class="footer-links">
+				<a href="/pricing">Pricing</a>
+				<a href="/policy/legal">Legal notices</a>
+				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
+			</div>
+			<p class="text-md-center mt-3">
+				<a href="/cv/jusmundi" class="btn btn-sm btn-outline-secondary">Jusmundi index</a>
+				<a href="/cv" class="btn btn-sm btn-outline-secondary ms-2">CV index</a>
+				<a href="#top" class="btn btn-sm btn-outline-secondary ms-2" aria-label="Back to top of page">Back to top</a>
+			</p>
+			<p class="text-muted small mt-2">NDA-safe infrastructure scope and outcomes.</p>
+			<p class="footer-copyright"></p>
+		</footer>
+		<script src="../../site-widgets.js" defer data-print-pdf data-coffee-fab></script>
+	</body>
+</html>

--- a/public/cv/jusmundi/jusmundi.css
+++ b/public/cv/jusmundi/jusmundi.css
@@ -1,0 +1,785 @@
+/**
+ * Jusmundi CV section — shared styles for index and review pages.
+ * Depends on: landing-sections.css, theme.css, cv-theme.css (--cv-* variables).
+ * Google Translate widget and print hiding are in theme.css.
+ */
+
+.jusmundi-page {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+		"Helvetica Neue", Arial, sans-serif;
+	line-height: 1.6;
+}
+
+/* CV-only pages (no site shell) */
+.jusmundi-page:not(.page-dark) {
+	color: var(--cv-text);
+	background-color: var(--cv-bg-page);
+}
+
+/* Index: align with site page-dark (theme.css) — body gradient + footer from theme */
+.jusmundi-page.page-dark {
+	color: var(--text-primary, #e2e8f0);
+	background: transparent;
+	min-height: 100vh;
+}
+
+.jusmundi-page:not(.page-dark) a {
+	color: var(--cv-link);
+}
+
+.jusmundi-page:not(.page-dark) a:hover {
+	color: var(--cv-link-hover);
+}
+
+/* Scope theme links to content chrome only (not footer / social) */
+.jusmundi-page.page-dark main a:not(.service-card):not(.btn) {
+	color: var(--link-color, var(--cv-link));
+}
+
+.jusmundi-page.page-dark nav.page-nav a:hover,
+.jusmundi-page.page-dark main a:not(.service-card):not(.btn):hover {
+	color: var(--link-hover, var(--cv-link-hover));
+}
+
+.jusmundi-page.page-dark main a.service-card {
+	color: inherit;
+}
+
+.jusmundi-page a:focus-visible,
+.jusmundi-page button:focus-visible {
+	outline: 2px solid var(--cv-heading-accent);
+	outline-offset: 2px;
+}
+
+.jusmundi-page.page-dark nav.page-nav a:focus-visible,
+.jusmundi-page.page-dark main a:focus-visible,
+.jusmundi-page.page-dark main button:focus-visible {
+	outline-color: var(--link-color, var(--cv-heading-accent));
+}
+
+.jusmundi-hero {
+	background: linear-gradient(
+		135deg,
+		var(--cv-btn-bg) 0%,
+		var(--cv-heading-accent) 100%
+	);
+	color: #fff;
+	padding: 2.5rem 1.5rem;
+	text-align: center;
+	border-radius: 0.5rem;
+	margin-bottom: 2rem;
+}
+
+.jusmundi-hero h1 {
+	margin: 0 0 0.5rem;
+	font-size: 1.75rem;
+}
+
+.jusmundi-hero .subtitle {
+	opacity: 0.95;
+	font-size: 1rem;
+}
+
+.jusmundi-section {
+	margin-bottom: 2.5rem;
+}
+
+.jusmundi-section h2 {
+	color: var(--cv-heading-accent);
+	font-size: 1.35rem;
+	margin-bottom: 1rem;
+	padding-bottom: 0.5rem;
+	border-bottom: 2px solid var(--cv-border-light);
+}
+
+.jusmundi-section h3 {
+	color: var(--cv-heading);
+	font-size: 1.1rem;
+	margin: 1.25rem 0 0.5rem;
+}
+
+.jusmundi-section-title {
+	text-align: center;
+	font-size: 1.75rem;
+	font-weight: 700;
+	margin-bottom: 0.5rem;
+	color: var(--cv-heading);
+}
+
+.jusmundi-section-subtitle {
+	text-align: center;
+	font-size: 1rem;
+	color: var(--cv-text-secondary);
+	margin-bottom: 1.5rem;
+}
+
+.jusmundi-section ul {
+	padding-left: 1.5rem;
+	margin: 0.5rem 0;
+}
+
+.jusmundi-section li {
+	margin-bottom: 0.35rem;
+}
+
+.back-link {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	margin-bottom: 1.5rem;
+	padding: 0.5rem 0;
+	color: var(--cv-link);
+	text-decoration: none;
+}
+
+.back-link:hover {
+	color: var(--cv-link-hover);
+	text-decoration: underline;
+}
+
+/* Jusmundi index (page-dark): glass panels like other site-content pages */
+.jusmundi-page.page-dark .services-section,
+.jusmundi-page.page-dark .proof-section {
+	background: transparent;
+	padding-left: 0;
+	padding-right: 0;
+}
+
+.jusmundi-page.page-dark .section-title {
+	color: var(--text-primary, var(--text-dark));
+}
+
+.jusmundi-page.page-dark .section-subtitle {
+	color: var(--text-secondary, var(--text-light));
+}
+
+.jusmundi-page.page-dark .service-card {
+	background: rgba(30, 41, 59, 0.7);
+	border: 1px solid rgba(71, 85, 105, 0.4);
+	backdrop-filter: blur(6px);
+	color: var(--text-primary, #e2e8f0);
+	box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+}
+
+.jusmundi-page.page-dark .service-card h3 {
+	color: var(--text-primary, #e2e8f0);
+}
+
+.jusmundi-page.page-dark .service-card p,
+.jusmundi-page.page-dark .service-card ul.service-bullets {
+	color: var(--text-secondary, #b8b8b8);
+}
+
+.jusmundi-page.page-dark .service-card .service-lead {
+	color: var(--text-primary, #e2e8f0);
+}
+
+.jusmundi-page.page-dark .service-icon {
+	color: var(--link-color, #66b3ff);
+}
+
+.jusmundi-page.page-dark a.service-card.jusmundi-doc-card {
+	background: rgba(30, 41, 59, 0.7);
+	border: 1px solid rgba(71, 85, 105, 0.4);
+	backdrop-filter: blur(6px);
+}
+
+.jusmundi-page.page-dark a.service-card.jusmundi-doc-card:hover {
+	border-color: rgba(96, 165, 250, 0.55);
+	box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+}
+
+.jusmundi-page.page-dark .kpi-card {
+	background: rgba(30, 41, 59, 0.7);
+	border: 1px solid rgba(71, 85, 105, 0.4);
+	backdrop-filter: blur(6px);
+}
+
+.jusmundi-page.page-dark .kpi-card .label {
+	color: var(--text-secondary, var(--cv-text-secondary));
+}
+
+.jusmundi-page.page-dark .jusmundi-source-notice {
+	background: rgba(30, 41, 59, 0.55);
+	border-color: rgba(71, 85, 105, 0.45);
+	color: var(--text-primary, var(--cv-text));
+}
+
+.jusmundi-page.page-dark .jusmundi-source-notice strong {
+	color: var(--text-primary, var(--cv-heading));
+}
+
+.jusmundi-page.page-dark .jusmundi-table-card {
+	background: rgba(30, 41, 59, 0.7);
+	border-color: rgba(71, 85, 105, 0.4);
+}
+
+html[data-theme="light"] .jusmundi-page.page-dark .service-card,
+html[data-theme="light"]
+	.jusmundi-page.page-dark
+	a.service-card.jusmundi-doc-card,
+html[data-theme="light"] .jusmundi-page.page-dark .kpi-card,
+html[data-theme="light"] .jusmundi-page.page-dark .jusmundi-table-card {
+	background: rgba(255, 255, 255, 0.85);
+	border-color: rgba(226, 232, 240, 0.9);
+}
+
+html[data-theme="light"] .jusmundi-page.page-dark .service-card h3,
+html[data-theme="light"] .jusmundi-page.page-dark .service-card .service-lead {
+	color: var(--text-primary, #0f172a);
+}
+
+html[data-theme="light"] .jusmundi-page.page-dark .service-card p,
+html[data-theme="light"]
+	.jusmundi-page.page-dark
+	.service-card
+	ul.service-bullets {
+	color: var(--text-secondary, #475569);
+}
+
+html[data-theme="light"] .jusmundi-page.page-dark .service-icon {
+	color: var(--primary-color, #2563eb);
+}
+
+html[data-theme="light"] .jusmundi-page.page-dark .jusmundi-source-notice {
+	background: var(--bg-secondary, #f1f5f9);
+	border-color: var(--border-color, #e2e8f0);
+	color: var(--text-primary);
+}
+
+html[data-theme="light"]
+	.jusmundi-page.page-dark
+	.jusmundi-source-notice
+	strong {
+	color: var(--text-primary);
+}
+
+/* Infrastructure costs page — tables in page-dark shell */
+.jusmundi-page.page-dark .infra-table-wrap {
+	background: rgba(30, 41, 59, 0.7);
+	border-color: rgba(71, 85, 105, 0.4);
+	backdrop-filter: blur(6px);
+}
+
+html[data-theme="light"] .jusmundi-page.page-dark .infra-table-wrap {
+	background: rgba(255, 255, 255, 0.85);
+	border-color: rgba(226, 232, 240, 0.9);
+}
+
+.jusmundi-page.page-dark .kpi-table {
+	color: var(--text-primary, var(--cv-text));
+}
+
+.jusmundi-page.page-dark .kpi-table th {
+	color: var(--text-primary, var(--cv-heading));
+	border-color: var(--border-color, var(--cv-border-light));
+}
+
+.jusmundi-page.page-dark .kpi-table td {
+	border-color: var(--border-color, var(--cv-border-light));
+}
+
+html[data-theme="light"] .jusmundi-page.page-dark .kpi-table,
+html[data-theme="light"] .jusmundi-page.page-dark .kpi-table th {
+	color: var(--text-primary, #0f172a);
+}
+
+/* KPI grid (index) */
+.kpi-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+	gap: 1.25rem;
+	margin: 1rem 0;
+}
+
+.kpi-card {
+	background: var(--cv-bg-card);
+	border: 1px solid var(--cv-border-light);
+	border-radius: 12px;
+	padding: 1.5rem 1rem;
+	text-align: center;
+	box-shadow: 0 2px 10px var(--cv-shadow);
+	transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.kpi-card:hover {
+	transform: translateY(-3px);
+	box-shadow: 0 8px 20px var(--cv-shadow);
+}
+
+.kpi-card .value {
+	font-size: 1.5rem;
+	font-weight: 700;
+	color: var(--cv-heading-accent);
+}
+
+.kpi-card .label {
+	font-size: 0.85rem;
+	color: var(--cv-text-secondary);
+	margin-top: 0.25rem;
+}
+
+/* KPI table (review pages) */
+.kpi-table {
+	width: 100%;
+	border-collapse: collapse;
+	margin: 1rem 0;
+	font-size: 0.95rem;
+}
+
+.kpi-table th,
+.kpi-table td {
+	border: 1px solid var(--cv-border-light);
+	padding: 0.6rem 0.75rem;
+	text-align: left;
+}
+
+.kpi-table th {
+	background: var(--cv-bg-highlight);
+	color: var(--cv-heading-accent);
+	font-weight: 600;
+}
+
+.kpi-table tbody tr:nth-child(even) {
+	background: var(--cv-bg-card);
+}
+
+.scorecard-pre {
+	font-family: ui-monospace, monospace;
+	font-size: 0.85rem;
+	background: var(--cv-bg-card);
+	border: 1px solid var(--cv-border-light);
+	border-radius: 8px;
+	padding: 1rem;
+	overflow-x: auto;
+	white-space: pre;
+}
+
+/* Lists */
+.achievement-list {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+}
+
+.achievement-list li {
+	padding: 0.5rem 0 0.5rem 1.75rem;
+	position: relative;
+	border-bottom: 1px solid var(--cv-border-light);
+}
+
+.achievement-list li:last-child {
+	border-bottom: none;
+}
+
+.achievement-list li::before {
+	content: "";
+	position: absolute;
+	left: 0;
+	top: 0.75rem;
+	width: 0.5rem;
+	height: 0.5rem;
+	background: var(--cv-heading-accent);
+	border-radius: 50%;
+}
+
+.badge-row {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	margin: 0.75rem 0;
+}
+
+.badge {
+	display: inline-block;
+	padding: 0.35rem 0.75rem;
+	font-size: 0.8rem;
+	font-weight: 600;
+	border-radius: 9999px;
+	background: var(--cv-bg-highlight);
+	color: var(--cv-heading-accent);
+	border: 1px solid var(--cv-border-light);
+}
+
+.summary-list {
+	list-style: none;
+	padding-left: 0;
+}
+
+.summary-list li {
+	padding-left: 1.5rem;
+	position: relative;
+	margin-bottom: 0.5rem;
+}
+
+.summary-list li::before {
+	content: "✓";
+	position: absolute;
+	left: 0;
+	color: var(--cv-heading-accent);
+	font-weight: bold;
+}
+
+/* Cards grid */
+.jusmundi-card {
+	background: var(--cv-bg-card);
+	padding: 1.75rem;
+	border-radius: 12px;
+	box-shadow: 0 2px 10px var(--cv-shadow);
+	transition: transform 0.2s ease, box-shadow 0.2s ease;
+	border: 1px solid var(--cv-border-light);
+}
+
+.jusmundi-card:hover {
+	transform: translateY(-3px);
+	box-shadow: 0 8px 20px var(--cv-shadow);
+}
+
+.jusmundi-card .jusmundi-card-icon {
+	font-size: 2rem;
+	color: var(--cv-heading-accent);
+	margin-bottom: 0.75rem;
+}
+
+.jusmundi-card h3 {
+	font-size: 1.25rem;
+	color: var(--cv-heading-accent);
+	margin-bottom: 0.5rem;
+}
+
+.jusmundi-card-subtitle {
+	font-size: 0.95rem;
+	color: var(--cv-text-secondary);
+	margin-bottom: 1rem;
+}
+
+.jusmundi-card-h4 {
+	font-size: 1.05rem;
+	color: var(--cv-heading);
+	margin: 1.25rem 0 0.5rem;
+	font-weight: 600;
+}
+
+.jusmundi-card-h4:first-of-type {
+	margin-top: 0.5rem;
+}
+
+.jusmundi-cards-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+	gap: 1.5rem;
+}
+
+/* AI / Notion source notice (Jusmundi review pages) */
+.jusmundi-source-notice {
+	margin: 0 0 1.75rem;
+	padding: 1rem 1.25rem;
+	border-radius: 10px;
+	border: 1px solid var(--cv-border-light);
+	background: var(--cv-bg-highlight);
+	color: var(--cv-text);
+	font-size: 0.95rem;
+	line-height: 1.55;
+}
+
+.jusmundi-source-notice strong {
+	color: var(--cv-heading);
+}
+
+.jusmundi-source-notice a {
+	font-weight: 600;
+}
+
+.jusmundi-source-notice p {
+	margin: 0;
+}
+
+/* Jusmundi HTML pages — index.html-style hero + services/proof sections (excludes cv-*.html CVs) */
+.jusmundi-landing-page .jusmundi-landing-content.services-section,
+.jusmundi-landing-page .jusmundi-landing-content.proof-section {
+	padding: 2.75rem 0;
+	margin-bottom: 0;
+}
+
+.jusmundi-landing-page .jusmundi-landing-content .section-title {
+	font-size: clamp(1.65rem, 3.5vw, 2.25rem);
+	margin-bottom: 1rem;
+}
+
+.jusmundi-landing-page .jusmundi-landing-content .section-subtitle {
+	margin-bottom: 1.5rem;
+}
+
+.jusmundi-landing-page .hero-section.jusmundi-hero-compact {
+	min-height: auto;
+	padding: 3rem 1.25rem;
+	border-radius: 12px;
+	margin-bottom: 2rem;
+	position: relative;
+	overflow: hidden;
+}
+
+.jusmundi-landing-page .jusmundi-hero-compact .hero-content {
+	padding: 0 0.75rem;
+}
+
+.jusmundi-landing-page .jusmundi-hero-compact .hero-title {
+	font-size: clamp(1.65rem, 4vw, 2.65rem);
+	margin-bottom: 1rem;
+	animation: none;
+}
+
+.jusmundi-landing-page .jusmundi-hero-compact .hero-subtitle {
+	font-size: 1.1rem;
+	max-width: 42rem;
+	margin-left: auto;
+	margin-right: auto;
+	animation: none;
+}
+
+.jusmundi-landing-page .jusmundi-service-card-wide {
+	text-align: left;
+}
+
+.jusmundi-landing-page .jusmundi-service-card-wide h3 {
+	text-align: left;
+}
+
+.jusmundi-landing-page .jusmundi-service-card-wide .service-bullets,
+.jusmundi-landing-page .jusmundi-service-card-wide ul.service-bullets {
+	max-width: none;
+	margin-left: 0;
+	margin-right: 0;
+}
+
+.jusmundi-landing-page a.service-card.jusmundi-doc-card {
+	display: block;
+	text-decoration: none;
+	color: inherit;
+	text-align: center;
+}
+
+.jusmundi-landing-page a.service-card.jusmundi-doc-card:hover {
+	color: inherit;
+}
+
+.jusmundi-landing-page .jusmundi-table-card {
+	overflow-x: auto;
+	-webkit-overflow-scrolling: touch;
+	border-radius: 10px;
+	border: 1px solid var(--border-color, var(--cv-border-light));
+	margin-top: 0.75rem;
+	box-shadow: 0 2px 8px var(--shadow-color, var(--cv-shadow));
+	background: var(--bg-white, var(--cv-bg-card));
+}
+
+.jusmundi-landing-page .jusmundi-table-card .kpi-table {
+	margin: 0;
+}
+
+.jusmundi-landing-page .jusmundi-kpi-section .kpi-grid {
+	margin-top: 0.25rem;
+}
+
+.jusmundi-landing-page .service-card .badge-row {
+	justify-content: center;
+}
+
+.jusmundi-landing-page .jusmundi-service-card-wide .badge-row {
+	justify-content: flex-start;
+}
+
+/* Skip link (accessibility) */
+.skip-link {
+	position: absolute;
+	top: -100px;
+	left: 0.5rem;
+	padding: 0.5rem 1rem;
+	background: var(--cv-heading-accent);
+	color: #fff;
+	text-decoration: none;
+	font-weight: 600;
+	z-index: 10000;
+	border-radius: 0 0 4px 0;
+	transition: top 0.2s;
+}
+
+.skip-link:focus {
+	top: 0;
+	outline: 2px solid currentColor;
+	outline-offset: 2px;
+}
+
+/* Infrastructure costs page — align with index.html landing sections */
+.infra-costs-page .infra-hero-landing {
+	background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+	box-shadow: 0 12px 40px rgba(102, 126, 234, 0.35);
+}
+
+.infra-costs-page .infra-costs-section.services-section {
+	padding: 2.5rem 0;
+	margin-bottom: 0;
+}
+
+.infra-costs-page .infra-costs-section.proof-section {
+	padding: 2.5rem 0;
+	margin-bottom: 0;
+}
+
+.infra-costs-page .infra-costs-section .section-title {
+	font-size: 2rem;
+}
+
+.infra-costs-page .infra-costs-section .section-subtitle {
+	margin-bottom: 1.5rem;
+}
+
+.infra-costs-page .infra-costs-note.section-subtitle {
+	margin-top: 0;
+	margin-bottom: 0;
+	padding: 0 1rem 1.5rem;
+	max-width: 40rem;
+	margin-left: auto;
+	margin-right: auto;
+}
+
+.infra-costs-page .infra-table-wrap {
+	overflow-x: auto;
+	-webkit-overflow-scrolling: touch;
+	border-radius: 12px;
+	border: 1px solid var(--border-color, var(--cv-border-light));
+	box-shadow: 0 2px 10px var(--shadow-color, var(--cv-shadow));
+	background: var(--bg-white, var(--cv-bg-card));
+}
+
+.infra-costs-page .infra-table-wrap .kpi-table {
+	margin: 0;
+}
+
+.infra-migration-band {
+	margin: 0 0 2rem;
+	padding: 2rem 1.25rem;
+	background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 45%, #1e3a8a 100%);
+	border-radius: 12px;
+	color: #fff;
+	box-shadow: 0 8px 28px rgba(37, 99, 235, 0.35);
+}
+
+.infra-migration-band .engagement-block {
+	margin: 0 auto;
+}
+
+.infra-migration-band .engagement-block .infra-migration-lead {
+	font-size: 1.05rem;
+	margin: 0 0 0.75rem;
+	line-height: 1.5;
+	opacity: 0.98;
+	color: #fff;
+}
+
+.infra-migration-band .engagement-block ul {
+	color: rgba(255, 255, 255, 0.95);
+}
+
+/* Featured “Top #1 achievement” band (Jusmundi index + infrastructure-costs) */
+.infra-migration-band-layout {
+	display: flex;
+	align-items: flex-start;
+	gap: 1.25rem;
+}
+
+.infra-migration-band-figure {
+	flex-shrink: 0;
+	width: 4rem;
+	height: 4rem;
+	border-radius: 14px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 1.65rem;
+	line-height: 1;
+	background: rgba(255, 255, 255, 0.16);
+	border: 1px solid rgba(255, 255, 255, 0.28);
+	box-shadow: 0 4px 14px rgba(0, 0, 0, 0.12);
+	color: #fff;
+}
+
+.infra-migration-band-body.engagement-block {
+	flex: 1;
+	min-width: 0;
+}
+
+.infra-top-achievement-pill {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.45rem;
+	margin: 0 0 0.65rem;
+	padding: 0.35rem 0.85rem;
+	font-size: 0.72rem;
+	font-weight: 700;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	line-height: 1.2;
+	color: #1e3a8a;
+	background: #fff;
+	border-radius: 999px;
+	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.12);
+}
+
+.infra-top-achievement-pill i {
+	font-size: 0.95rem;
+	color: #1d4ed8;
+	opacity: 0.95;
+}
+
+.infra-migration-band .engagement-block h3 {
+	margin: 0 0 0.65rem;
+	font-size: clamp(1.05rem, 2.5vw, 1.35rem);
+	font-weight: 700;
+	line-height: 1.35;
+	color: #fff;
+}
+
+@media (max-width: 576px) {
+	.infra-migration-band-layout {
+		flex-direction: column;
+		align-items: center;
+		text-align: center;
+	}
+
+	.infra-migration-band-body.engagement-block {
+		text-align: center;
+	}
+
+	.infra-top-achievement-pill {
+		margin-inline: auto;
+	}
+
+	.infra-migration-band .engagement-block ul {
+		text-align: left;
+	}
+}
+
+@media (max-width: 768px) {
+	.kpi-grid {
+		grid-template-columns: repeat(2, 1fr);
+	}
+
+	.jusmundi-cards-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.kpi-table {
+		font-size: 0.8rem;
+	}
+
+	.kpi-table th,
+	.kpi-table td {
+		padding: 0.4rem;
+	}
+
+	.infra-costs-page .infra-costs-section.services-section,
+	.infra-costs-page .infra-costs-section.proof-section {
+		padding: 1.75rem 0;
+	}
+}

--- a/public/cv/jusmundi/structure.html
+++ b/public/cv/jusmundi/structure.html
@@ -1,0 +1,234 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>JusMundi — Team context and collaboration model | Alban Andrieu</title>
+		<meta
+			name="description"
+			content="Public team composition and collaboration context for a DevOps and Senior Architect role at JusMundi."
+		/>
+		<meta name="keywords" content="Alban Andrieu, JusMundi, DevOps, Senior Architect, team structure, CV" />
+		<meta name="author" content="Alban Andrieu" />
+		<meta name="robots" content="noindex, nofollow" />
+		<meta name="referrer" content="always" />
+		<meta name="color-scheme" content="light dark" />
+		<meta name="image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://dr-alban.com/cv/jusmundi/structure.html" />
+		<meta property="og:title" content="JusMundi — Team context and collaboration model | Alban Andrieu" />
+		<meta
+			property="og:description"
+			content="Public team composition and collaboration context for a DevOps and Senior Architect role at JusMundi."
+		/>
+		<meta property="og:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
+		<meta property="twitter:card" content="summary" />
+		<meta property="twitter:url" content="https://dr-alban.com/cv/jusmundi/structure.html" />
+		<meta property="twitter:title" content="JusMundi — Team context and collaboration model" />
+		<meta
+			property="twitter:description"
+			content="Public team composition used to describe cross-functional DevOps collaboration."
+		/>
+		<meta property="twitter:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
+		<link rel="canonical" href="https://dr-alban.com/cv/jusmundi/structure.html" />
+		<link rel="icon" href="../../assets/nabla/nabla-4.svg" />
+		<link rel="stylesheet" href="../../landing-sections.css" />
+		<link rel="stylesheet" href="../../theme.css" />
+		<link rel="stylesheet" href="../cv-theme.css" />
+		<link rel="stylesheet" href="../../wireframe.css" />
+		<link rel="stylesheet" href="../../print.css" />
+		<link rel="stylesheet" href="../../style.css" />
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.1/css/bootstrap.min.css"
+			integrity="sha512-siwe/oXMhSjGCwLn+scraPOWrJxHlUgMBMZXdPe2Tnk3I0x3ESCoLz7WZ5NTH6SZrywMY+PB1cjyqJ5jAluCOg=="
+			crossorigin="anonymous"
+			referrerpolicy="no-referrer"
+		/>
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.9.1/font/bootstrap-icons.min.css"
+			integrity="sha512-5PV92qsds/16vyYIJo3T/As4m2d8b6oWYfoqV+vtizRB6KhF1F9kYzWzQmsO6T3z3QG2Xdhrx7FQ+5R1LiQdUA=="
+			crossorigin="anonymous"
+			referrerpolicy="no-referrer"
+		/>
+		<link rel="stylesheet" href="../../site-content-page.css" />
+		<link rel="stylesheet" href="jusmundi.css" />
+		<link href="/assets/fontawesome/css/fontawesome.css" rel="stylesheet" />
+		<link href="/assets/fontawesome/css/brands.css" rel="stylesheet" />
+		<link href="/assets/fontawesome/css/solid.css" rel="stylesheet" />
+		<script src="../../theme-toggle.js"></script>
+		<script src="../../site-google-translate.js" defer></script>
+		<script src="../../site-analytics.js"></script>
+	</head>
+	<body class="site-content-page jusmundi-page jusmundi-landing-page page-dark">
+		<a name="top"></a>
+		<a href="#main-content" class="skip-link">Skip to main content</a>
+		<nav class="page-nav container py-3 d-flex flex-wrap align-items-center gap-2" aria-label="Breadcrumb">
+			<a href="/cv/jusmundi" class="text-decoration-none" aria-label="Back to Jusmundi index">
+				<span aria-hidden="true">←</span> Jusmundi
+			</a>
+			<span class="opacity-75" aria-hidden="true">·</span>
+			<a href="/cv" class="text-decoration-none" aria-label="Back to CV index">CV index</a>
+		</nav>
+		<main id="main-content" role="main" class="container py-4 pb-5">
+			<section class="hero-section jusmundi-hero-compact" aria-labelledby="hero-heading">
+				<div class="hero-content">
+					<h1 class="hero-title" id="hero-heading">Team context and collaboration model</h1>
+					<p class="hero-subtitle">
+						Public figures only, used to explain how DevOps and architecture leadership created cross-team impact
+					</p>
+				</div>
+			</section>
+			<section class="proof-section jusmundi-landing-content" aria-labelledby="featured-heading">
+				<h2 class="section-title" id="featured-heading">Featured teams and proportions</h2>
+				<div class="service-card jusmundi-service-card-wide">
+					<div class="jusmundi-table-card">
+						<table class="kpi-table" role="table" aria-label="Featured team composition">
+							<thead>
+								<tr>
+									<th scope="col">Team</th>
+									<th scope="col">Approx. size</th>
+									<th scope="col">Approx. share</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Tech</td>
+									<td>~25</td>
+									<td>~38%</td>
+								</tr>
+								<tr>
+									<td>Global Sales</td>
+									<td>~21</td>
+									<td>~32%</td>
+								</tr>
+								<tr>
+									<td>Product</td>
+									<td>~10</td>
+									<td>~15%</td>
+								</tr>
+								<tr>
+									<td>Customer Success / Care</td>
+									<td>~10</td>
+									<td>~15%</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+					<p class="mt-3 mb-0">
+						These percentages come from public team information and are sufficient to show operating context without
+						exposing private organizational data.
+					</p>
+				</div>
+			</section>
+			<section class="services-section jusmundi-landing-content" aria-labelledby="devops-heading">
+				<h2 class="section-title" id="devops-heading">DevOps collaboration footprint</h2>
+				<div class="services-grid">
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-code-branch"></i></div>
+						<h3>With engineering and product</h3>
+						<p class="service-lead">
+							Platform standards, CI/CD consistency, and architecture guardrails to increase delivery velocity.
+						</p>
+					</div>
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-shield-halved"></i></div>
+						<h3>With customer-facing teams</h3>
+						<p class="service-lead">
+							Reliability and security improvements that protect customer experience and support scalable growth.
+						</p>
+					</div>
+					<div class="service-card">
+						<div class="service-icon" aria-hidden="true"><i class="fas fa-sitemap"></i></div>
+						<h3>With leadership and operations</h3>
+						<p class="service-lead">
+							Operational governance, cost-awareness, and risk-aware prioritization for sustainable execution.
+						</p>
+					</div>
+				</div>
+			</section>
+			<section class="proof-section jusmundi-landing-content" aria-labelledby="operating-heading">
+				<h2 class="section-title" id="operating-heading">How the team model supported architecture impact</h2>
+				<div class="service-card jusmundi-service-card-wide">
+					<ul class="summary-list">
+						<li>Cross-functional operating model enabled decisions to move from RFC to implementation faster.</li>
+						<li>Shared quality and security practices reduced handoff friction between squads.</li>
+						<li>Platform-as-a-product mindset improved autonomy while preserving governance.</li>
+					</ul>
+				</div>
+			</section>
+			<section class="services-section jusmundi-landing-content" aria-labelledby="documents-heading">
+				<h2 class="section-title" id="documents-heading">Related documents</h2>
+				<div class="service-card jusmundi-service-card-wide">
+					<p>
+						<a href="/cv/jusmundi" class="back-link">← Back to Jusmundi index</a>
+						<span class="mx-2" aria-hidden="true">·</span>
+						<a href="4-years-review-jusmundi.html" class="back-link">Company history and positioning</a>
+						<span class="mx-2" aria-hidden="true">·</span>
+						<a href="infrastructure-costs.html" class="back-link">Infrastructure overview</a>
+						<span class="mx-2" aria-hidden="true">·</span>
+						<a href="4-years-review-aandrieu.html" class="back-link">Senior architect achievements</a>
+					</p>
+				</div>
+			</section>
+		</main>
+		<footer class="footer" role="contentinfo">
+			<div class="social-links">
+				<a
+					href="https://www.linkedin.com/in/nabla"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="LinkedIn"
+					><i class="fab fa-linkedin-in"></i
+				></a>
+				<a
+					href="https://calendly.com/alban-andrieu"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="Calendly"
+					><i class="fa fa-calendar-plus"></i
+				></a>
+				<a
+					href="https://github.com/AlbanAndrieu"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="GitHub"
+					><i class="fab fa-github"></i
+				></a>
+				<a
+					href="https://hub.docker.com/u/nabla"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="Docker Hub"
+					><i class="fab fa-docker"></i
+				></a>
+				<a
+					href="https://stackexchange.com/users/4652074/albanandrieu"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="Stack Exchange"
+					><i class="fab fa-stack-exchange"></i
+				></a>
+			</div>
+			<div class="footer-links">
+				<a href="/pricing">Pricing</a>
+				<a href="/policy/legal">Legal notices</a>
+				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
+			</div>
+			<p class="text-md-center mt-3">
+				<a href="/cv/jusmundi" class="btn btn-sm btn-outline-secondary">Jusmundi index</a>
+				<a href="/cv" class="btn btn-sm btn-outline-secondary ms-2">CV index</a>
+				<a href="#top" class="btn btn-sm btn-outline-secondary ms-2" aria-label="Back to top of page">Back to top</a>
+			</p>
+			<p class="text-muted small mt-2">Public team context and collaboration model.</p>
+			<p class="footer-copyright"></p>
+		</footer>
+		<script src="../../site-widgets.js" defer data-print-pdf data-coffee-fab></script>
+	</body>
+</html>

--- a/public/cv/jusmundi/structure.html
+++ b/public/cv/jusmundi/structure.html
@@ -217,7 +217,6 @@
 				></a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing.html">Pricing</a>
 				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>

--- a/public/cv/jusmundi/structure.html
+++ b/public/cv/jusmundi/structure.html
@@ -217,8 +217,8 @@
 				></a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing">Pricing</a>
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/pricing.html">Pricing</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/cv/jusmundi/structure.html
+++ b/public/cv/jusmundi/structure.html
@@ -65,11 +65,11 @@
 		<a name="top"></a>
 		<a href="#main-content" class="skip-link">Skip to main content</a>
 		<nav class="page-nav container py-3 d-flex flex-wrap align-items-center gap-2" aria-label="Breadcrumb">
-			<a href="/cv/jusmundi" class="text-decoration-none" aria-label="Back to Jusmundi index">
-				<span aria-hidden="true">←</span> Jusmundi
+			<a href="/cv/jusmundi" class="text-decoration-none" aria-label="Back to JusMundi index">
+				<span aria-hidden="true">←</span> JusMundi
 			</a>
 			<span class="opacity-75" aria-hidden="true">·</span>
-			<a href="/cv" class="text-decoration-none" aria-label="Back to CV index">CV index</a>
+			<a href="/cv" class="text-decoration-none" aria-label="Back to CV index">Return to CV</a>
 		</nav>
 		<main id="main-content" role="main" class="container py-4 pb-5">
 			<section class="hero-section jusmundi-hero-compact" aria-labelledby="hero-heading">
@@ -158,20 +158,6 @@
 					</ul>
 				</div>
 			</section>
-			<section class="services-section jusmundi-landing-content" aria-labelledby="documents-heading">
-				<h2 class="section-title" id="documents-heading">Related documents</h2>
-				<div class="service-card jusmundi-service-card-wide">
-					<p>
-						<a href="/cv/jusmundi" class="back-link">← Back to Jusmundi index</a>
-						<span class="mx-2" aria-hidden="true">·</span>
-						<a href="4-years-review-jusmundi.html" class="back-link">Company history and positioning</a>
-						<span class="mx-2" aria-hidden="true">·</span>
-						<a href="infrastructure-costs.html" class="back-link">Infrastructure overview</a>
-						<span class="mx-2" aria-hidden="true">·</span>
-						<a href="4-years-review-aandrieu.html" class="back-link">Senior architect achievements</a>
-					</p>
-				</div>
-			</section>
 		</main>
 		<footer class="footer" role="contentinfo">
 			<div class="social-links">
@@ -221,9 +207,8 @@
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">
-				<a href="/cv/jusmundi" class="btn btn-sm btn-outline-secondary">Jusmundi index</a>
-				<a href="/cv" class="btn btn-sm btn-outline-secondary ms-2">CV index</a>
-				<a href="#top" class="btn btn-sm btn-outline-secondary ms-2" aria-label="Back to top of page">Back to top</a>
+				<a href="/cv/jusmundi" class="btn btn-sm btn-outline-secondary">Return to JusMundi index</a>
+				<a href="/cv" class="btn btn-sm btn-outline-secondary ms-2">Return to CV</a>
 			</p>
 			<p class="text-muted small mt-2">Public team context and collaboration model.</p>
 			<p class="footer-copyright"></p>

--- a/public/cv/jusmundi/yearly-review-2025-aandrieu.html
+++ b/public/cv/jusmundi/yearly-review-2025-aandrieu.html
@@ -1,0 +1,184 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Senior Architect Review — Latest Year Execution | Alban Andrieu</title>
+		<meta
+			name="description"
+			content="NDA-safe yearly review focused on senior architect execution, measurable impact, and leadership outcomes."
+		/>
+		<meta
+			name="keywords"
+			content="Alban Andrieu, senior architect, DevOps, platform engineering, yearly review, achievements"
+		/>
+		<meta name="author" content="Alban Andrieu" />
+		<meta name="robots" content="noindex, nofollow" />
+		<meta name="referrer" content="always" />
+		<meta name="color-scheme" content="light dark" />
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://dr-alban.com/cv/jusmundi/yearly-review-2025-aandrieu.html" />
+		<meta property="og:title" content="Senior Architect Review — Latest Year Execution" />
+		<meta property="og:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
+		<meta property="twitter:card" content="summary" />
+		<meta property="twitter:url" content="https://dr-alban.com/cv/jusmundi/yearly-review-2025-aandrieu.html" />
+		<meta property="twitter:title" content="Senior Architect Review — Latest Year Execution" />
+		<meta property="twitter:image" content="https://dr-alban.com/assets/nabla/nabla-4.svg" />
+		<link rel="canonical" href="https://dr-alban.com/cv/jusmundi/yearly-review-2025-aandrieu.html" />
+		<link rel="icon" href="../../assets/nabla/nabla-4.svg" />
+		<link rel="stylesheet" href="../../landing-sections.css" />
+		<link rel="stylesheet" href="../../theme.css" />
+		<link rel="stylesheet" href="../cv-theme.css" />
+		<link rel="stylesheet" href="../../wireframe.css" />
+		<link rel="stylesheet" href="../../print.css" />
+		<link rel="stylesheet" href="../../style.css" />
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.1/css/bootstrap.min.css"
+			integrity="sha512-siwe/oXMhSjGCwLn+scraPOWrJxHlUgMBMZXdPe2Tnk3I0x3ESCoLz7WZ5NTH6SZrywMY+PB1cjyqJ5jAluCOg=="
+			crossorigin="anonymous"
+			referrerpolicy="no-referrer"
+		/>
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.9.1/font/bootstrap-icons.min.css"
+			integrity="sha512-5PV92qsds/16vyYIJo3T/As4m2d8b6oWYfoqV+vtizRB6KhF1F9kYzWzQmsO6T3z3QG2Xdhrx7FQ+5R1LiQdUA=="
+			crossorigin="anonymous"
+			referrerpolicy="no-referrer"
+		/>
+		<link rel="stylesheet" href="../../site-content-page.css" />
+		<link rel="stylesheet" href="jusmundi.css" />
+		<link href="/assets/fontawesome/css/fontawesome.css" rel="stylesheet" />
+		<link href="/assets/fontawesome/css/brands.css" rel="stylesheet" />
+		<link href="/assets/fontawesome/css/solid.css" rel="stylesheet" />
+		<script src="../../theme-toggle.js"></script>
+		<script src="../../site-google-translate.js" defer></script>
+		<script src="../../site-analytics.js"></script>
+	</head>
+	<body class="site-content-page jusmundi-page jusmundi-landing-page page-dark">
+		<a name="top"></a>
+		<a href="#main-content" class="skip-link">Skip to main content</a>
+
+		<nav class="page-nav container py-3 d-flex flex-wrap align-items-center gap-2" aria-label="Breadcrumb">
+			<a href="/cv/jusmundi" class="text-decoration-none" aria-label="Back to Jusmundi index">
+				<span aria-hidden="true">←</span> Jusmundi
+			</a>
+			<span class="opacity-75" aria-hidden="true">·</span>
+			<a href="/cv" class="text-decoration-none" aria-label="Back to CV index">CV index</a>
+		</nav>
+
+		<main id="main-content" role="main" class="container py-4 pb-5">
+			<section class="hero-section jusmundi-hero-compact" aria-labelledby="hero-heading">
+				<div class="hero-content">
+					<h1 class="hero-title" id="hero-heading">Latest Year Review — Senior Architect Execution</h1>
+					<p class="hero-subtitle">NDA-safe summary focused on delivery outcomes and leadership impact</p>
+				</div>
+			</section>
+
+			<section class="proof-section jusmundi-landing-content" aria-labelledby="scope-heading">
+				<h2 class="section-title" id="scope-heading">Execution scope</h2>
+				<div class="service-card jusmundi-service-card-wide">
+					<p>
+						This yearly cycle focused on platform reliability, security hardening, delivery acceleration, and
+						cross-team enablement. The work was executed across multiple environments with a constant objective:
+						improving operational performance while preserving product velocity.
+					</p>
+				</div>
+			</section>
+
+			<section class="services-section jusmundi-landing-content" aria-labelledby="impact-heading">
+				<h2 class="section-title" id="impact-heading">Measured outcomes</h2>
+				<div class="service-card jusmundi-service-card-wide">
+					<ul class="summary-list">
+						<li>Alert noise reduced by ~60%, improving signal quality and incident focus.</li>
+						<li>Incident recovery times reduced by around 50% for high-priority operational events.</li>
+						<li>Manual configuration errors reduced by ~90% via architecture and automation patterns.</li>
+						<li>Critical remediation cycle time reduced by more than 50% through security process maturity.</li>
+						<li>Service reliability and release confidence improved through stronger delivery standards.</li>
+					</ul>
+				</div>
+			</section>
+
+			<section class="proof-section jusmundi-landing-content" aria-labelledby="leadership-heading">
+				<h2 class="section-title" id="leadership-heading">Leadership contribution</h2>
+				<div class="service-card jusmundi-service-card-wide">
+					<ul class="service-bullets">
+						<li>Defined and enforced reusable platform standards across teams.</li>
+						<li>Improved collaboration between engineering, product, and go-to-market stakeholders.</li>
+						<li>Drove execution in high-pressure situations while protecting long-term architecture quality.</li>
+						<li>Balanced reliability, security, and speed without exposing sensitive platform details.</li>
+					</ul>
+				</div>
+			</section>
+
+			<section class="services-section jusmundi-landing-content" aria-labelledby="positioning-heading">
+				<h2 class="section-title" id="positioning-heading">Senior architect positioning</h2>
+				<div class="service-card jusmundi-service-card-wide">
+					<p>
+						This year consolidates a senior architect profile with strong platform ownership, measurable improvements,
+						and proven execution at scale. The contribution is both strategic and operational: shaping direction while
+						delivering concrete results.
+					</p>
+				</div>
+			</section>
+		</main>
+
+		<footer class="footer" role="contentinfo">
+			<div class="social-links">
+				<a
+					href="https://www.linkedin.com/in/nabla"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="LinkedIn"
+					><i class="fab fa-linkedin-in"></i
+				></a>
+				<a
+					href="https://calendly.com/alban-andrieu"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="Calendly"
+					><i class="fa fa-calendar-plus"></i
+				></a>
+				<a
+					href="https://github.com/AlbanAndrieu"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="GitHub"
+					><i class="fab fa-github"></i
+				></a>
+				<a
+					href="https://hub.docker.com/u/nabla"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="Docker Hub"
+					><i class="fab fa-docker"></i
+				></a>
+				<a
+					href="https://stackexchange.com/users/4652074/albanandrieu"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="social-link"
+					aria-label="Stack Exchange"
+					><i class="fab fa-stack-exchange"></i
+				></a>
+			</div>
+			<div class="footer-links">
+				<a href="/pricing">Pricing</a>
+				<a href="/policy/legal">Legal notices</a>
+				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
+			</div>
+			<p class="text-md-center mt-3">
+				<a href="/cv/jusmundi" class="btn btn-sm btn-outline-secondary">Jusmundi index</a>
+				<a href="/cv" class="btn btn-sm btn-outline-secondary ms-2">CV index</a>
+				<a href="#top" class="btn btn-sm btn-outline-secondary ms-2" aria-label="Back to top of page">Back to top</a>
+			</p>
+			<p class="text-muted small mt-2">NDA-safe yearly execution summary.</p>
+			<p class="footer-copyright"></p>
+		</footer>
+		<script src="../../site-widgets.js" defer data-print-pdf data-coffee-fab></script>
+	</body>
+</html>

--- a/public/cv/jusmundi/yearly-review-2025-aandrieu.html
+++ b/public/cv/jusmundi/yearly-review-2025-aandrieu.html
@@ -6,7 +6,7 @@
 		<title>Senior Architect Review — Latest Year Execution | Alban Andrieu</title>
 		<meta
 			name="description"
-			content="NDA-safe yearly review focused on senior architect execution, measurable impact, and leadership outcomes."
+			content="Yearly review focused on senior architect execution, measurable impact, and leadership outcomes."
 		/>
 		<meta
 			name="keywords"
@@ -71,7 +71,7 @@
 			<section class="hero-section jusmundi-hero-compact" aria-labelledby="hero-heading">
 				<div class="hero-content">
 					<h1 class="hero-title" id="hero-heading">Latest Year Review — Senior Architect Execution</h1>
-					<p class="hero-subtitle">NDA-safe summary focused on delivery outcomes and leadership impact</p>
+					<p class="hero-subtitle">Summary focused on delivery outcomes and leadership impact</p>
 				</div>
 			</section>
 
@@ -106,7 +106,7 @@
 						<li>Defined and enforced reusable platform standards across teams.</li>
 						<li>Improved collaboration between engineering, product, and go-to-market stakeholders.</li>
 						<li>Drove execution in high-pressure situations while protecting long-term architecture quality.</li>
-						<li>Balanced reliability, security, and speed without exposing sensitive platform details.</li>
+						<li>Balanced reliability, security, and speed while maintaining strong platform governance.</li>
 					</ul>
 				</div>
 			</section>
@@ -176,7 +176,7 @@
 				<a href="/cv" class="btn btn-sm btn-outline-secondary ms-2">CV index</a>
 				<a href="#top" class="btn btn-sm btn-outline-secondary ms-2" aria-label="Back to top of page">Back to top</a>
 			</p>
-			<p class="text-muted small mt-2">NDA-safe yearly execution summary.</p>
+			<p class="text-muted small mt-2">Yearly execution summary.</p>
 			<p class="footer-copyright"></p>
 		</footer>
 		<script src="../../site-widgets.js" defer data-print-pdf data-coffee-fab></script>

--- a/public/cv/jusmundi/yearly-review-2025-aandrieu.html
+++ b/public/cv/jusmundi/yearly-review-2025-aandrieu.html
@@ -60,11 +60,11 @@
 		<a href="#main-content" class="skip-link">Skip to main content</a>
 
 		<nav class="page-nav container py-3 d-flex flex-wrap align-items-center gap-2" aria-label="Breadcrumb">
-			<a href="/cv/jusmundi" class="text-decoration-none" aria-label="Back to Jusmundi index">
-				<span aria-hidden="true">←</span> Jusmundi
+			<a href="/cv/jusmundi" class="text-decoration-none" aria-label="Back to JusMundi index">
+				<span aria-hidden="true">←</span> JusMundi
 			</a>
 			<span class="opacity-75" aria-hidden="true">·</span>
-			<a href="/cv" class="text-decoration-none" aria-label="Back to CV index">CV index</a>
+			<a href="/cv" class="text-decoration-none" aria-label="Back to CV index">Return to CV</a>
 		</nav>
 
 		<main id="main-content" role="main" class="container py-4 pb-5">
@@ -171,9 +171,8 @@
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">
-				<a href="/cv/jusmundi" class="btn btn-sm btn-outline-secondary">Jusmundi index</a>
-				<a href="/cv" class="btn btn-sm btn-outline-secondary ms-2">CV index</a>
-				<a href="#top" class="btn btn-sm btn-outline-secondary ms-2" aria-label="Back to top of page">Back to top</a>
+				<a href="/cv/jusmundi" class="btn btn-sm btn-outline-secondary">Return to JusMundi index</a>
+				<a href="/cv" class="btn btn-sm btn-outline-secondary ms-2">Return to CV</a>
 			</p>
 			<p class="text-muted small mt-2">Yearly execution summary.</p>
 			<p class="footer-copyright"></p>

--- a/public/cv/jusmundi/yearly-review-2025-aandrieu.html
+++ b/public/cv/jusmundi/yearly-review-2025-aandrieu.html
@@ -167,8 +167,8 @@
 				></a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing">Pricing</a>
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/pricing.html">Pricing</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/cv/jusmundi/yearly-review-2025-aandrieu.html
+++ b/public/cv/jusmundi/yearly-review-2025-aandrieu.html
@@ -167,7 +167,6 @@
 				></a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing.html">Pricing</a>
 				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>

--- a/public/email-contact-addresses.html
+++ b/public/email-contact-addresses.html
@@ -248,7 +248,7 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/example-js.html
+++ b/public/example-js.html
@@ -80,8 +80,8 @@
 				></a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing">Pricing</a>
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/pricing.html">Pricing</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/example-js.html
+++ b/public/example-js.html
@@ -80,7 +80,6 @@
 				></a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing.html">Pricing</a>
 				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>

--- a/public/expertise.html
+++ b/public/expertise.html
@@ -196,26 +196,6 @@
 					</div>
 				</div>
 
-				<div class="engagement-block">
-					<h3>Engagement models</h3>
-					<p class="engagement-tjm" lang="fr">
-						Daily rate &nbsp;: <strong>750&nbsp;€ à 790&nbsp;€</strong>
-						<span class="engagement-tjm-note" lang="en"> (day rate, ex. VAT)</span>
-					</p>
-					<ul>
-						<li><strong>Fractional DevSecOps / cloud architect</strong> — typically 1–3 days per week.</li>
-						<li>
-							<strong>Short audits and assessments</strong> — often 2–4 weeks for architecture, security or CI/CD.
-						</li>
-						<li>
-							<strong>Project-based delivery</strong> — defined scope (e.g. migration, compliance sprint, platform
-							build).
-						</li>
-					</ul>
-					<p class="engagement-pricing-link">
-						— how retainers, audits and projects are usually structured.
-					</p>
-				</div>
 			</section>
 
 			<section class="services-section section-tight-top" id="ai-mlops" aria-labelledby="ai-mlops-heading">

--- a/public/expertise.html
+++ b/public/expertise.html
@@ -213,7 +213,6 @@
 						</li>
 					</ul>
 					<p class="engagement-pricing-link">
-						<a href="pricing.html">Pricing &amp; engagement options</a>
 						— how retainers, audits and projects are usually structured.
 					</p>
 				</div>

--- a/public/expertise.html
+++ b/public/expertise.html
@@ -97,7 +97,7 @@
 		<a href="#main-content" class="skip-to-main">Skip to main content</a>
 
 		<nav class="page-nav container py-3" aria-label="Breadcrumb">
-			<a href="/" class="text-decoration-none"><i class="fas fa-home" aria-hidden="true"></i> Back to home</a>
+			<a href="index.html" class="text-decoration-none"><i class="fas fa-home" aria-hidden="true"></i> Back to home</a>
 		</nav>
 
 		<main id="main-content" role="main">
@@ -199,7 +199,7 @@
 				<div class="engagement-block">
 					<h3>Engagement models</h3>
 					<p class="engagement-tjm" lang="fr">
-						Daily rate &nbsp;: <strong>Starting at 750&nbsp;€</strong>
+						Daily rate &nbsp;: <strong>750&nbsp;€ à 790&nbsp;€</strong>
 						<span class="engagement-tjm-note" lang="en"> (day rate, ex. VAT)</span>
 					</p>
 					<ul>
@@ -213,7 +213,7 @@
 						</li>
 					</ul>
 					<p class="engagement-pricing-link">
-						<a href="/pricing">Pricing &amp; engagement options</a>
+						<a href="pricing.html">Pricing &amp; engagement options</a>
 						— how retainers, audits and projects are usually structured.
 					</p>
 				</div>
@@ -333,7 +333,7 @@
 					</div>
 				</div>
 				<p class="skills-more">
-					<a href="/cv" target="_blank" rel="noopener noreferrer">View full CVs &amp; formats</a>
+					<a href="/cv/index.html" target="_blank" rel="noopener noreferrer">View full CVs &amp; formats</a>
 				</p>
 			</section>
 		</main>
@@ -387,10 +387,10 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/policy/legal.html">Legal notices</a>
 			</div>
 			<p class="text-md-center mt-3">
-				<a href="/" class="btn btn-sm btn-outline-secondary">Back to Home</a>
+				<a href="index.html" class="btn btn-sm btn-outline-secondary">Back to Home</a>
 				<a href="#top" class="btn btn-sm btn-outline-secondary" aria-label="Back to top of page">Back to top</a>
 			</p>
 			<p class="footer-copyright"></p>

--- a/public/freenas.html
+++ b/public/freenas.html
@@ -1080,7 +1080,6 @@
 			</div>
 
 			<div class="footer-links">
-				<a href="/pricing.html">Pricing</a>
 				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer">Cookies</a>
 			</div>

--- a/public/freenas.html
+++ b/public/freenas.html
@@ -100,7 +100,7 @@
 		<nav class="page-nav container py-3" aria-label="Breadcrumb">
 			<a href="/" class="text-decoration-none"><i class="fas fa-home" aria-hidden="true"></i> Back to home</a>
 			<span class="text-muted mx-2" aria-hidden="true">·</span>
-			<a href="/truenas" class="text-decoration-none">TrueNAS</a>
+			<a href="/truenas.html" class="text-decoration-none">TrueNAS</a>
 			<span class="text-muted mx-2" aria-hidden="true">·</span>
 			<span class="text-muted">FreeNAS (archive)</span>
 		</nav>
@@ -156,21 +156,21 @@
 												</div>
 											</div>
 											<button type="button" class="btn btn-sm btn-outline-secondary">
-												<a href="/01_nabla/index.html">Report</a>
+												<a href="/nabla.html">Report</a>
 											</button>
 											<div class="btn-group btn-group-sm">
 												<button class="btn dropdown-toggle btn-success" data-toggle="dropdown">Download&nbsp;</button>
 												<div class="dropdown-menu">
 													<a class="dropdown-item" download href="/cv/cv-aandrieu-XX-XX-2021.tex">*.tex</a>
 													<div class="dropdown-divider"></div>
-													<a class="dropdown-item" download href="/cv/cv-aandrieu-XX-XX-2021.pdf">*.pdf</a>
+													<a class="dropdown-item" download href="/cv/index.html">*.pdf</a>
 													<div class="dropdown-divider"></div>
-													<a class="dropdown-item" download href="/01_nabla/index.html">*.html</a>
+													<a class="dropdown-item" download href="/nabla.html">*.html</a>
 													<div class="dropdown-divider"></div>
 													<!--
-		                    <a class="dropdown-item" download href="/01_nabla/nabla_report.txt">*.txt</a>
+		                    <a class="dropdown-item" download href="/reports/monitoring_report.html">*.txt</a>
 		                    <div class="dropdown-divider"></div>
-		                    <a class="dropdown-item" download href="/01_nabla/nabla_report.zip">*.zip</a>
+		                    <a class="dropdown-item" download href="/reports/monitoring_report.html">*.zip</a>
 		                    <div class="dropdown-divider"></div>
 		                    -->
 													<a
@@ -885,7 +885,7 @@
 										<i class="fa mr-2 fa-clipboard" aria-hidden="true"></i>
 										ALL
 										<b
-											><a href="summary_onoff/index.html" target="_blank" rel="noopener noreferrer">[click]</a> ONLINE /
+											><a href="/truenas.html" target="_blank" rel="noopener noreferrer">[click]</a> ONLINE /
 											OFFLINE</b
 										>
 										nodes assigned to Jenkins instances
@@ -1080,8 +1080,8 @@
 			</div>
 
 			<div class="footer-links">
-				<a href="/pricing">Pricing</a>
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/pricing.html">Pricing</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer">Cookies</a>
 			</div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -214,10 +214,10 @@
 						>
 							<i class="fa fa-calendar-plus"></i> Book a 30-minute consultation
 						</a>
-						<a href="/startup" class="btn btn-outline-light">
+						<a href="/startup.html" class="btn btn-outline-light">
 							<i class="fas fa-rocket" aria-hidden="true"></i> Start your project!
 						</a>
-						<a href="/cv/cv-aandrieu-2026-en.pdf" class="btn btn-secondary" target="_blank" rel="noopener noreferrer">
+						<a href="/cv/cv-full-en.html" class="btn btn-secondary" target="_blank" rel="noopener noreferrer">
 							<i class="fas fa-file-pdf"></i> Download one-page profile (PDF)
 						</a>
 						<a
@@ -228,7 +228,7 @@
 						>
 							<i class="fab fa-linkedin"></i> View LinkedIn
 						</a>
-						<a href="/expertise" class="btn btn-secondary">
+						<a href="/expertise.html" class="btn btn-secondary">
 							<i class="fas fa-layer-group" aria-hidden="true"></i> Services &amp; technical expertise
 						</a>
 						<!--
@@ -280,7 +280,7 @@
 					</div>
 				</div>
 				<p class="section-subtitle mt-4 mb-0">
-					<a href="/expertise">More detail on selected outcomes</a>
+					<a href="/expertise.html">More detail on selected outcomes</a>
 				</p>
 			</section>
 
@@ -461,7 +461,7 @@
 							data-protection frameworks. <strong>ISO 42001</strong> — lead implementer for AI management systems.
 							<strong>SOC 2 Type II</strong>
 							— security controls and attestation in line with trust services criteria. See also
-							<a href="/security#security-standards-compliance">Security standards &amp; compliance</a>.
+							<a href="/security.html#security-standards-compliance">Security standards &amp; compliance</a>.
 						</p>
 					</div>
 
@@ -609,7 +609,7 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/policy/legal.html">Legal notices</a>
 			</div>
 			<p class="text-md-center mt-3">
 				<a href="#top" class="btn btn-sm btn-outline-secondary" aria-label="Back to top of page">Back to top</a>

--- a/public/link.html
+++ b/public/link.html
@@ -98,7 +98,7 @@
 		<nav class="page-nav container py-3" aria-label="Breadcrumb">
 			<a href="/" class="text-decoration-none"><i class="fas fa-home" aria-hidden="true"></i> Back to home</a>
 			<span class="text-muted mx-2" aria-hidden="true">·</span>
-			<a href="/nabla" class="text-decoration-none">Nabla overview</a>
+			<a href="/nabla.html" class="text-decoration-none">Nabla overview</a>
 		</nav>
 
 		<main id="main-content" role="main" class="container py-4 pb-5">
@@ -106,7 +106,7 @@
 				<h1 class="h2 mb-2">Profiles &amp; registries in use</h1>
 				<p class="section-subtitle mb-0">
 					Public profiles and registries referenced from the
-					<a href="/nabla">Nabla</a>
+					<a href="/nabla.html">Nabla</a>
 					DevSecOps overview.
 				</p>
 			</header>
@@ -218,8 +218,8 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing">Pricing</a>
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/pricing.html">Pricing</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/link.html
+++ b/public/link.html
@@ -218,7 +218,6 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing.html">Pricing</a>
 				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>

--- a/public/login.html
+++ b/public/login.html
@@ -14,7 +14,6 @@
     <meta name="keywords" content="login" />
     <meta name="author" content="alban.andrieu@dr-alban.com" />
 
-
 		<!-- Font Awesome -->
     <link
       rel="stylesheet"
@@ -30,8 +29,6 @@
 		<link href="/assets/fontawesome/css/fontawesome.css" rel="stylesheet" />
 		<link href="/assets/fontawesome/css/brands.css" rel="stylesheet" />
 		<link href="/assets/fontawesome/css/solid.css" rel="stylesheet" />
-
-
 
 		<link rel="stylesheet" href="landing-sections.css" />
 		<link rel="stylesheet" href="wireframe.css" />
@@ -152,7 +149,6 @@
         <a href="https://stackexchange.com/users/4652074/albanandrieu" target="_blank" rel="noopener noreferrer" class="social-link" aria-label="Stack Exchange"><i class="fab fa-stack-exchange"></i></a>
       </div>
       <div class="footer-links">
-        <a href="/pricing.html">Pricing</a>
         <a href="/policy/legal.html">Legal notices</a>
         <a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
       </div>
@@ -163,8 +159,6 @@
       <p class="footer-copyright"></p>
     </footer>
 		<!-- End footer section -->
-
-
 
 		<script
 			src="https://uptime.betterstack.com/widgets/announcement.js"

--- a/public/login.html
+++ b/public/login.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="robots" content="noindex, nofollow" />
     <!-- PAGE settings -->
-    <link rel="icon" href="index/assets/nabla/nabla-4.svg" />
+    <link rel="icon" href="assets/nabla/nabla-4.svg" />
     <title>Nabla - Login</title>
     <meta name="description" content="logi." />
     <meta name="keywords" content="login" />
@@ -152,8 +152,8 @@
         <a href="https://stackexchange.com/users/4652074/albanandrieu" target="_blank" rel="noopener noreferrer" class="social-link" aria-label="Stack Exchange"><i class="fab fa-stack-exchange"></i></a>
       </div>
       <div class="footer-links">
-        <a href="/pricing">Pricing</a>
-        <a href="/policy/legal">Legal notices</a>
+        <a href="/pricing.html">Pricing</a>
+        <a href="/policy/legal.html">Legal notices</a>
         <a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
       </div>
       <p class="text-md-center mt-3">

--- a/public/maintenance/index.html
+++ b/public/maintenance/index.html
@@ -80,7 +80,6 @@
 				></a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing.html">Pricing</a>
 				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>

--- a/public/maintenance/index.html
+++ b/public/maintenance/index.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<!-- PAGE settings -->
-		<link rel="icon" href="assets/nabla/nabla-4.svg" />
+		<link rel="icon" href="../assets/nabla/nabla-4.svg" />
 		<title>INDEX for albandrieu.com</title>
 		<meta name="robots" content="noindex, nofollow" />
 
@@ -80,8 +80,8 @@
 				></a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing">Pricing</a>
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/pricing.html">Pricing</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/nabla.html
+++ b/public/nabla.html
@@ -169,7 +169,7 @@
 		<nav class="page-nav container py-3" aria-label="Breadcrumb">
 			<a href="/" class="text-decoration-none"><i class="fas fa-home" aria-hidden="true"></i> Back to home</a>
 			<span class="text-muted mx-2" aria-hidden="true">·</span>
-			<a href="/truenas" class="text-decoration-none">TrueNAS</a>
+			<a href="/truenas.html" class="text-decoration-none">TrueNAS</a>
 			<span class="text-muted mx-2" aria-hidden="true">·</span>
 			<span class="text-muted">Nabla project</span>
 		</nav>
@@ -579,7 +579,7 @@
 						</h3>
 						<p class="text-secondary small mb-3">
 							Full Truenas services listed:
-							<a href="/truenas" target="_blank" rel="noopener noreferrer" class="link-secondary text-break">here</a>
+							<a href="/truenas.html" target="_blank" rel="noopener noreferrer" class="link-secondary text-break">here</a>
 						</p>
 
 						<div
@@ -647,7 +647,7 @@
 					</div>
 
 					<p class="tools-grid-heading mb-0">
-						<a href="/link">Profiles &amp; registries in use</a>
+						<a href="/link.html">Profiles &amp; registries in use</a>
 						<span class="text-muted"> — GitHub, SonarCloud, Docker Hub, </span>
 						<a
 							href="https://nexus.albandrieu.com"
@@ -836,8 +836,8 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing">Pricing</a>
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/pricing.html">Pricing</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/nabla.html
+++ b/public/nabla.html
@@ -836,7 +836,6 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing.html">Pricing</a>
 				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>

--- a/public/payment.html
+++ b/public/payment.html
@@ -87,7 +87,6 @@
 		<nav class="page-nav container py-3" aria-label="Breadcrumb">
 			<a href="/" class="text-decoration-none"><i class="fas fa-home" aria-hidden="true"></i> Back to home</a>
 			<span class="text-muted mx-2" aria-hidden="true">·</span>
-			<a href="/pricing.html" class="text-decoration-none">Pricing</a>
 			<span class="text-muted mx-2" aria-hidden="true">·</span>
 			<a href="/contact.html" class="text-decoration-none">Contact</a>
 		</nav>
@@ -201,7 +200,6 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing.html">Pricing</a>
 				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>

--- a/public/payment.html
+++ b/public/payment.html
@@ -87,9 +87,9 @@
 		<nav class="page-nav container py-3" aria-label="Breadcrumb">
 			<a href="/" class="text-decoration-none"><i class="fas fa-home" aria-hidden="true"></i> Back to home</a>
 			<span class="text-muted mx-2" aria-hidden="true">·</span>
-			<a href="/pricing" class="text-decoration-none">Pricing</a>
+			<a href="/pricing.html" class="text-decoration-none">Pricing</a>
 			<span class="text-muted mx-2" aria-hidden="true">·</span>
-			<a href="/contact" class="text-decoration-none">Contact</a>
+			<a href="/contact.html" class="text-decoration-none">Contact</a>
 		</nav>
 
 		<main id="main-content" role="main" class="checkout-page payment-options">
@@ -112,7 +112,7 @@
 					</div>
 				</div>
 				<p class="mb-0 mt-3">
-					<a href="/checkout" class="checkout-button w-100 text-center">
+					<a href="/checkout.html" class="checkout-button w-100 text-center">
 						<i class="fa-solid fa-lock" aria-hidden="true"></i>
 						<span class="ms-1">Continue to Stripe checkout</span>
 					</a>
@@ -121,7 +121,7 @@
 					If checkout does not start, use this
 					<a href="https://buy.stripe.com/9B65kF1Gd8hHcr2d69cV200" rel="noopener noreferrer"
 						>direct Stripe payment link</a
-					>, <a href="#pay-sepa">pay by bank transfer (SEPA)</a>, or <a href="/contact">get in touch</a>.
+					>, <a href="#pay-sepa">pay by bank transfer (SEPA)</a>, or <a href="/contact.html">get in touch</a>.
 				</p>
 			</section>
 
@@ -201,8 +201,8 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing">Pricing</a>
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/pricing.html">Pricing</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/policy/accessibility_statement.html
+++ b/public/policy/accessibility_statement.html
@@ -10,7 +10,7 @@
 		/>
 		<meta name="keywords" content="accessibility, WCAG, a11y, digital accessibility, bababou" />
 		<meta name="robots" content="index, follow" />
-		<link rel="canonical" href="/policy/accessibility_statement" />
+		<link rel="canonical" href="/policy/accessibility_statement.html" />
 
 		<!-- Open Graph meta tags for social media sharing -->
 		<meta property="og:type" content="website" />
@@ -199,12 +199,12 @@
 				></a>
 			</div>
 			<div class="footer-links">
-				<a href="/policy/service_terms">Terms of Use</a>
+				<a href="/policy/service_terms.html">Terms of Use</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
-				<a href="/policy/privacy_policy">Privacy Policy</a>
-				<a href="/policy/impressum">Impressum</a>
-				<a href="/policy/accessibility_statement">Accessibility</a>
-				<a href="/policy/cookie_policy">Cookie Policy</a>
+				<a href="/policy/privacy_policy.html">Privacy Policy</a>
+				<a href="/policy/impressum.html">Impressum</a>
+				<a href="/policy/accessibility_statement.html">Accessibility</a>
+				<a href="/policy/cookie_policy.html">Cookie Policy</a>
 			</div>
 			<p class="text-md-center mt-3">
 				<a href="/" class="btn btn-sm btn-outline-secondary">Back to Home</a>

--- a/public/policy/cookie_policy.html
+++ b/public/policy/cookie_policy.html
@@ -10,7 +10,7 @@
 		/>
 		<meta name="keywords" content="cookies, cookie policy, consent, bababou" />
 		<meta name="robots" content="index, follow" />
-		<link rel="canonical" href="/policy/cookie_policy" />
+		<link rel="canonical" href="/policy/cookie_policy.html" />
 
 		<!-- Open Graph meta tags for social media sharing -->
 		<meta property="og:type" content="website" />
@@ -73,7 +73,7 @@
 
 			<p>
 				This policy explains how we use cookies and similar technologies on this website, in line with the ePrivacy
-				directive and the GDPR. For general data processing, see our <a href="/policy/privacy_policy">Privacy Policy</a>.
+				directive and the GDPR. For general data processing, see our <a href="/policy/privacy_policy.html">Privacy Policy</a>.
 			</p>
 
 			<h2>1. What are cookies?</h2>
@@ -125,7 +125,7 @@
 
 			<p>
 				For questions or to exercise your rights regarding personal data processed via cookies, see the
-				<a href="/policy/privacy_policy">Privacy Policy</a> and the contact details given there.
+				<a href="/policy/privacy_policy.html">Privacy Policy</a> and the contact details given there.
 			</p>
 		</main>
 
@@ -204,12 +204,12 @@
 				></a>
 			</div>
 			<div class="footer-links">
-				<a href="/policy/service_terms">Terms of Use</a>
+				<a href="/policy/service_terms.html">Terms of Use</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
-				<a href="/policy/privacy_policy">Privacy Policy</a>
-				<a href="/policy/impressum">Impressum</a>
-				<a href="/policy/accessibility_statement">Accessibility</a>
-				<a href="/policy/cookie_policy">Cookie Policy</a>
+				<a href="/policy/privacy_policy.html">Privacy Policy</a>
+				<a href="/policy/impressum.html">Impressum</a>
+				<a href="/policy/accessibility_statement.html">Accessibility</a>
+				<a href="/policy/cookie_policy.html">Cookie Policy</a>
 			</div>
 			<p class="text-md-center mt-3">
 				<a href="/" class="btn btn-sm btn-outline-secondary">Back to Home</a>

--- a/public/policy/impressum.html
+++ b/public/policy/impressum.html
@@ -10,7 +10,7 @@
 		/>
 		<meta name="keywords" content="impressum, legal notice, mentions légales, publisher, bababou" />
 		<meta name="robots" content="index, follow" />
-		<link rel="canonical" href="/policy/impressum" />
+		<link rel="canonical" href="/policy/impressum.html" />
 
 		<!-- Open Graph meta tags for social media sharing -->
 		<meta property="og:type" content="website" />
@@ -115,14 +115,14 @@
 			<p>
 				Content is provided to the best of our knowledge. We do not guarantee completeness or accuracy. We are not
 				liable for external links or third-party content. For data protection, see our
-				<a href="/policy/privacy_policy">Privacy Policy</a>; for terms of use, see our
-				<a href="/policy/service_terms">Terms of Use</a>.
+				<a href="/policy/privacy_policy.html">Privacy Policy</a>; for terms of use, see our
+				<a href="/policy/service_terms.html">Terms of Use</a>.
 			</p>
 
 			<h2>4. Copyright and intellectual property</h2>
 			<p>
 				Texts, layout and original materials on this site are subject to copyright. Reproduction or use beyond personal
-				consultation may require permission. See the <a href="/policy/service_terms">Terms of Use</a> for details.
+				consultation may require permission. See the <a href="/policy/service_terms.html">Terms of Use</a> for details.
 			</p>
 		</main>
 
@@ -201,12 +201,12 @@
 				></a>
 			</div>
 			<div class="footer-links">
-				<a href="/policy/service_terms">Terms of Use</a>
+				<a href="/policy/service_terms.html">Terms of Use</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
-				<a href="/policy/privacy_policy">Privacy Policy</a>
-				<a href="/policy/impressum">Impressum</a>
-				<a href="/policy/accessibility_statement">Accessibility</a>
-				<a href="/policy/cookie_policy">Cookie Policy</a>
+				<a href="/policy/privacy_policy.html">Privacy Policy</a>
+				<a href="/policy/impressum.html">Impressum</a>
+				<a href="/policy/accessibility_statement.html">Accessibility</a>
+				<a href="/policy/cookie_policy.html">Cookie Policy</a>
 			</div>
 			<p class="text-md-center mt-3">
 				<a href="/" class="btn btn-sm btn-outline-secondary">Back to Home</a>

--- a/public/policy/legal.html
+++ b/public/policy/legal.html
@@ -188,7 +188,6 @@
 				></a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing.html">Pricing</a>
 				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>

--- a/public/policy/legal.html
+++ b/public/policy/legal.html
@@ -118,7 +118,7 @@
 			</p>
 			<p>
 				For full detail, see the
-				<a href="/policy/privacy_policy">Privacy Policy</a>.
+				<a href="/policy/privacy_policy.html">Privacy Policy</a>.
 			</p>
 
 			<h2>Use of the site &amp; liability</h2>
@@ -129,7 +129,7 @@
 			</p>
 			<p>
 				For the complete contractual terms governing use, see the
-				<a href="/policy/service_terms">Terms of Service</a>.
+				<a href="/policy/service_terms.html">Terms of Service</a>.
 			</p>
 
 			<h2>Intellectual property &amp; trademarks</h2>
@@ -188,8 +188,8 @@
 				></a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing">Pricing</a>
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/pricing.html">Pricing</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/policy/privacy_policy.html
+++ b/public/policy/privacy_policy.html
@@ -209,7 +209,7 @@
 				></a>
 			</div>
 			<div class="footer-links">
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/policy/service_terms.html
+++ b/public/policy/service_terms.html
@@ -223,7 +223,7 @@
 				></a>
 			</div>
 			<div class="footer-links">
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/pricing.html
+++ b/public/pricing.html
@@ -100,7 +100,7 @@
 		<nav class="page-nav container py-3" aria-label="Breadcrumb">
 			<a href="/" class="text-decoration-none"><i class="fas fa-home" aria-hidden="true"></i> Back to home</a>
 			<span class="text-muted mx-2" aria-hidden="true">·</span>
-			<a href="/contact" class="text-decoration-none">Contact</a>
+			<a href="/contact.html" class="text-decoration-none">Contact</a>
 		</nav>
 
 		<main id="main-content" role="main" class="container py-4 pb-5 pricing-page">
@@ -253,7 +253,7 @@
 					>
 						<i class="fa fa-calendar-plus" aria-hidden="true"></i> Book intro call
 					</a>
-					<a href="/expertise#services" class="btn btn-outline-secondary">Back to services</a>
+					<a href="/expertise.html#services" class="btn btn-outline-secondary">Back to services</a>
 				</div>
 			</section>
 
@@ -312,7 +312,7 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/policy/legal.html">Legal notices</a>
 			</div>
 			<p class="text-md-center mt-3">
 				<a href="/" class="btn btn-sm btn-outline-secondary">Back to Home</a>

--- a/public/security.html
+++ b/public/security.html
@@ -1256,7 +1256,6 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing.html">Pricing</a>
 				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>

--- a/public/security.html
+++ b/public/security.html
@@ -295,7 +295,7 @@
 				<p>Comprehensive collection of security resources for DevSecOps professionals</p>
 				<p>
 					Curated by
-					<a href="/contact" style="color: white; text-decoration: underline">Alban Andrieu</a>
+					<a href="/contact.html" style="color: white; text-decoration: underline">Alban Andrieu</a>
 				</p>
 				<p>
 					<a href="#security-standards-compliance" style="color: white; text-decoration: underline"
@@ -608,13 +608,13 @@
 							</a>
 						</li>
 						<li>
-							<a href="/ai#nvidia-openshell">
+							<a href="/ai.html#nvidia-openshell">
 								<i class="fa-solid fa-brain"></i>
 								NVIDIA OpenShell — AI page (sandboxed agent runtime)
 							</a>
 						</li>
 						<li>
-							<a href="/ai#open-terminal">
+							<a href="/ai.html#open-terminal">
 								<i class="fa-solid fa-terminal"></i>
 								Open Terminal — AI page (self-hosted terminal API for agents)
 							</a>
@@ -1256,8 +1256,8 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing">Pricing</a>
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/pricing.html">Pricing</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -73,7 +73,7 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://dr-alban.com/cv/jusmundi</loc>
+    <loc>https://dr-alban.com/cv/jusmundi/</loc>
     <lastmod>2026-04-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.75</priority>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -68,9 +68,15 @@
   </url>
   <url>
     <loc>https://dr-alban.com/cv</loc>
-    <lastmod>2026-01-28</lastmod>
+    <lastmod>2026-04-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://dr-alban.com/cv/jusmundi</loc>
+    <lastmod>2026-04-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.75</priority>
   </url>
   <url>
     <loc>https://dr-alban.com/cv/cv-aandrieu-XX-XX-2026.pdf</loc>

--- a/public/startup-thanks.html
+++ b/public/startup-thanks.html
@@ -48,12 +48,12 @@
 				<a href="https://calendly.com/alban-andrieu" target="_blank" rel="noopener noreferrer">schedule a call</a>.
 			</p>
 			<a href="/" class="btn btn-primary me-2">Back to home</a>
-			<a href="/startup" class="btn btn-outline-secondary">Send another message</a>
+			<a href="/startup.html" class="btn btn-outline-secondary">Send another message</a>
 		</main>
 
 		<footer class="footer" role="contentinfo">
 			<div class="footer-links">
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/policy/legal.html">Legal notices</a>
 			</div>
 			<p class="footer-copyright"></p>
 		</footer>

--- a/public/startup.html
+++ b/public/startup.html
@@ -61,7 +61,6 @@
 		<nav class="page-nav container py-3" aria-label="Breadcrumb">
 			<a href="/" class="text-decoration-none"><i class="fas fa-home" aria-hidden="true"></i> Back to home</a>
 			<span class="text-muted mx-2" aria-hidden="true">·</span>
-			<a href="/pricing.html" class="text-decoration-none">Pricing</a>
 			<span class="text-muted mx-2" aria-hidden="true">·</span>
 			<a href="/contact.html" class="text-decoration-none">Contact</a>
 		</nav>

--- a/public/startup.html
+++ b/public/startup.html
@@ -61,9 +61,9 @@
 		<nav class="page-nav container py-3" aria-label="Breadcrumb">
 			<a href="/" class="text-decoration-none"><i class="fas fa-home" aria-hidden="true"></i> Back to home</a>
 			<span class="text-muted mx-2" aria-hidden="true">·</span>
-			<a href="/pricing" class="text-decoration-none">Pricing</a>
+			<a href="/pricing.html" class="text-decoration-none">Pricing</a>
 			<span class="text-muted mx-2" aria-hidden="true">·</span>
-			<a href="/contact" class="text-decoration-none">Contact</a>
+			<a href="/contact.html" class="text-decoration-none">Contact</a>
 		</nav>
 
 		<main id="main-content" role="main" class="container py-4 pb-5 col-lg-8">
@@ -158,8 +158,8 @@
 
 						<p class="small text-secondary mb-3">
 							By sending this form you agree that your message is used only to respond to your request, as described in
-							the <a href="/policy/legal">legal notices</a> and
-							<a href="/policy/privacy_policy">privacy policy</a>.
+							the <a href="/policy/legal.html">legal notices</a> and
+							<a href="/policy/privacy_policy.html">privacy policy</a>.
 						</p>
 
 						<button type="submit" class="btn btn-primary">
@@ -219,7 +219,7 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/policy/legal.html">Legal notices</a>
 			</div>
 			<p class="text-md-center mt-3">
 				<a href="/" class="btn btn-sm btn-outline-secondary">Back to Home</a>

--- a/public/success.html
+++ b/public/success.html
@@ -7,10 +7,10 @@
 		<meta name="robots" content="noindex, nofollow" />
 
 		<!-- Favicon -->
-		<link rel="icon" href="../assets/nabla/nabla-4.svg" />
+		<link rel="icon" href="assets/nabla/nabla-4.svg" />
 
 		<!-- Resume Schema Reference for Machine-Readable Tools -->
-		<link rel="alternate" type="application/json" href="./schema.json" title="Resume Schema (JSONResume format)" />
+		<link rel="alternate" type="application/json" href="/cv/schema.json" title="Resume Schema (JSONResume format)" />
 
 		<!-- Font Awesome -->
 		<link
@@ -34,16 +34,16 @@
 		<!-- Theme toggle script - load early to prevent flash -->
 
 		<!-- Custom CSS -->
-		<link rel="stylesheet" href="../landing-sections.css" />
+		<link rel="stylesheet" href="landing-sections.css" />
 
-		<link rel="stylesheet" href="../wireframe.css" />
-		<link rel="stylesheet" href="../arf.css" />
-		<link rel="stylesheet" href="../theme.css" />
+		<link rel="stylesheet" href="wireframe.css" />
+		<link rel="stylesheet" href="arf.css" />
+		<link rel="stylesheet" href="theme.css" />
 
-		<link rel="stylesheet" href="../style.css" />
+		<link rel="stylesheet" href="style.css" />
 		<!-- Print Styles for PDF Export -->
-		<link rel="stylesheet" href="../print.css" />
-		<link rel="stylesheet" href="../site-content-page.css" />
+		<link rel="stylesheet" href="print.css" />
+		<link rel="stylesheet" href="site-content-page.css" />
 
 		<link rel="stylesheet" href="checkout.css" />
 		<script src="theme-toggle.js"></script>
@@ -69,7 +69,7 @@
 					<a href="mailto:invoice@dr-alban.com">invoice@dr-alban.com</a>.
 				</p>
 				<p class="checkout-actions">
-					<a href="/checkout" class="checkout-button checkout-button-secondary">Make another payment</a>
+					<a href="/checkout.html" class="checkout-button checkout-button-secondary">Make another payment</a>
 					<a href="/" class="checkout-button">Back to site</a>
 				</p>
 			</section>
@@ -118,7 +118,7 @@
 				></a>
 			</div>
 			<div class="footer-links">
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/test.html
+++ b/public/test.html
@@ -212,7 +212,7 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer" class="text-muted">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">

--- a/public/truenas.html
+++ b/public/truenas.html
@@ -435,7 +435,6 @@
 			</div>
 
 			<div class="footer-links">
-				<a href="/pricing.html">Pricing</a>
 				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer">Cookies</a>
 			</div>

--- a/public/truenas.html
+++ b/public/truenas.html
@@ -102,7 +102,7 @@
 		<nav class="page-nav container py-3" aria-label="Breadcrumb">
 			<a href="/" class="text-decoration-none"><i class="fas fa-home" aria-hidden="true"></i> Back to home</a>
 			<span class="text-muted mx-2" aria-hidden="true">·</span>
-			<a href="/freenas" class="text-decoration-none">FreeNAS (archive)</a>
+			<a href="/freenas.html" class="text-decoration-none">FreeNAS (archive)</a>
 			<span class="text-muted mx-2" aria-hidden="true">·</span>
 			<span class="text-muted">TrueNAS Scale</span>
 		</nav>
@@ -151,7 +151,7 @@
 								<div class="card-body text-center border-top border-secondary">
 									<h3 class="h5 card-title mb-1">Nabla</h3>
 									<p class="card-text text-muted small mb-0">Nabla &amp; project</p>
-									<a href="/nabla" class="btn btn-sm btn-outline-primary mt-3">Open nabla project</a>
+									<a href="/nabla.html" class="btn btn-sm btn-outline-primary mt-3">Open nabla project</a>
 								</div>
 							</div>
 						</div>
@@ -217,7 +217,7 @@
 										></span>
 										<span class="hardware-bom-intro__text">
 											After seven years of good service, my
-											<a href="/freenas">FreeNAS</a>
+											<a href="/freenas.html">FreeNAS</a>
 											server died. The goal is to extend the setup beyond a NAS alone: a
 											<strong>homelab</strong> on <strong>TrueNAS Scale</strong>, with applications for domotics such as
 											<strong>Home Assistant</strong>, plus security and AI tooling, as listed below on this page.
@@ -435,8 +435,8 @@
 			</div>
 
 			<div class="footer-links">
-				<a href="/pricing">Pricing</a>
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/pricing.html">Pricing</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer">Cookies</a>
 			</div>
 

--- a/public/workstation.html
+++ b/public/workstation.html
@@ -761,7 +761,6 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing.html">Pricing</a>
 				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer">Cookies</a>
 			</div>

--- a/public/workstation.html
+++ b/public/workstation.html
@@ -72,7 +72,7 @@
 		<nav class="page-nav container py-3" aria-label="Breadcrumb">
 			<a href="/" class="text-decoration-none"><i class="fas fa-home" aria-hidden="true"></i> Back to home</a>
 			<span class="text-muted mx-2" aria-hidden="true">·</span>
-			<a href="/truenas" class="text-decoration-none">TrueNAS Scale</a>
+			<a href="/truenas.html" class="text-decoration-none">TrueNAS Scale</a>
 			<span class="text-muted mx-2" aria-hidden="true">·</span>
 			<span class="text-muted">Workstation</span>
 		</nav>
@@ -89,7 +89,7 @@
 							</p>
 							<p class="text-secondary mb-0 mt-3">
 								For the NAS-side catalog, see
-								<a href="/truenas">TrueNAS Scale services</a>.
+								<a href="/truenas.html">TrueNAS Scale services</a>.
 							</p>
 						</div>
 					</div>
@@ -694,7 +694,7 @@
 								<div class="card-body">
 									<h3 class="h6 card-title">TrueNAS Scale</h3>
 									<p class="card-text text-muted small mb-0">Homelab apps and hardware on the NAS.</p>
-									<a href="/truenas" class="btn btn-sm btn-outline-primary mt-3">Open TrueNAS page</a>
+									<a href="/truenas.html" class="btn btn-sm btn-outline-primary mt-3">Open TrueNAS page</a>
 								</div>
 							</div>
 						</div>
@@ -703,7 +703,7 @@
 								<div class="card-body">
 									<h3 class="h6 card-title">Nabla</h3>
 									<p class="card-text text-muted small mb-0">Project context on this site.</p>
-									<a href="/nabla" class="btn btn-sm btn-outline-primary mt-3">Open Nabla</a>
+									<a href="/nabla.html" class="btn btn-sm btn-outline-primary mt-3">Open Nabla</a>
 								</div>
 							</div>
 						</div>
@@ -761,8 +761,8 @@
 				</a>
 			</div>
 			<div class="footer-links">
-				<a href="/pricing">Pricing</a>
-				<a href="/policy/legal">Legal notices</a>
+				<a href="/pricing.html">Pricing</a>
+				<a href="/policy/legal.html">Legal notices</a>
 				<a href="javascript:openAxeptioCookies()" rel="noopener noreferrer">Cookies</a>
 			</div>
 			<p class="text-md-center mt-3">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
This PR restores and restructures the JusMundi CV portfolio content, restores `expertise.html` from history, fixes internal link reachability, removes pricing links from site navigation, aligns style/content consistency across all JusMundi pages, and fixes Playwright startup failures.

## What changed
- Restored `public/cv/jusmundi/` pages and shared stylesheet.
- Reorganized content around requested structure:
  1. JusMundi description and history
  2. Team context for DevOps role (size and percentages)
  3. Global infrastructure description
  4. Projects/tasks over 4 years with outcome-oriented highlights
- Aggregated `structure.html` and `infrastructure-costs.html` content into `public/cv/jusmundi/index.html`.
- Reintroduced key achievements/projects in `4-years-review-aandrieu.html`.
- Restored `public/expertise.html` from git history.
- Removed the Engagement models block from `public/expertise.html`.
- Removed the Data Driven figures section from `public/cv/index.html`.
- Removed pricing links across site pages while keeping `public/pricing.html`.
- Restored the first PR version of `public/cv/jusmundi/index.html` and removed the Detailed pages cards section.

## JusMundi consistency pass
- Reviewed all pages in `public/cv/jusmundi/` for broken links, redundancy, and style consistency.
- Verified internal links are reachable across all six JusMundi pages.
- Removed remaining NDA-labeled wording on `public/cv/jusmundi/index.html` (meta descriptions, hero subtitle, footer helper text).
- Removed leftover pricing footer link from `public/cv/jusmundi/index.html`.
- Standardized naming and navigation labels to `JusMundi` / `Return to CV` across JusMundi pages.
- Removed redundant footer "Back to top" buttons (handled globally by `site-widgets.js`).
- Removed redundant "Related documents" section from `public/cv/jusmundi/structure.html`.
- Unified footer legal link format to `/policy/legal.html` across JusMundi pages.

## Playwright fixes
- Updated test web server command to use `python3` instead of `python`:
  - `package.json` script `start:python`
- This resolves test startup failure in environments where `python` alias is not present.

## Files touched in latest passes
- `public/cv/jusmundi/index.html`
- `public/cv/jusmundi/4-years-review-jusmundi.html`
- `public/cv/jusmundi/4-years-review-aandrieu.html`
- `public/cv/jusmundi/yearly-review-2025-aandrieu.html`
- `public/cv/jusmundi/structure.html`
- `public/cv/jusmundi/infrastructure-costs.html`
- `package.json`

## Validation
- Internal link audit for `public/cv/jusmundi/*.html`: no broken internal links found.
- Search checks for unwanted tokens in JusMundi pages: no `NDA-safe`, no `/pricing`, no `Pricing` anchors, no explicit footer `Back to top` links.
- Playwright test suite passes after environment setup and script fix:
  - `npm test` → success (all tests green in this environment).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c86a1e4-0d88-474a-9c60-9724722e790f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c86a1e4-0d88-474a-9c60-9724722e790f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

